### PR TITLE
Update mkdocs deps and add lint stage to CI

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,21 +12,16 @@ concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  # Opt JavaScript actions into Node.js 24 ahead of the June 2026 default.
-  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Lint markdown
-        uses: DavidAnson/markdownlint-cli2-action@v18
+        uses: DavidAnson/markdownlint-cli2-action@v23
         with:
           globs: |
             docs/**/*.md
@@ -45,13 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           lfs: true
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -64,7 +59,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ github.workspace }}/site
 
@@ -85,4 +80,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,6 +12,11 @@ concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  # Opt JavaScript actions into Node.js 24 ahead of the June 2026 default.
+  # https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -4,28 +4,70 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v1
-      - name: "Pull git lfs"
-        run: git lfs pull
-      - name: "Setup Environment"
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Lint markdown
+        uses: DavidAnson/markdownlint-cli2-action@v18
+        with:
+          globs: |
+            docs/**/*.md
+            readme.md
+          config: .markdownlint.yaml
+
+      - name: Lint YAML
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .yamllint.yaml
+          file_or_dir: mkdocs.yml .github/workflows
+
+  build:
+    name: Build
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: mkdocs.requirements
+
+      - name: Install dependencies
         run: pip install -r mkdocs.requirements
 
-      - name: "Build mkdocs"
-        run: mkdocs build
+      - name: Build mkdocs (strict)
+        run: mkdocs build --strict
 
-      - name: "Save build artifact"
-        uses: actions/upload-pages-artifact@v1.0.8
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ github.workspace }}/site
 
   deploy:
+    name: Deploy
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: build
+    runs-on: ubuntu-latest
 
     permissions:
       pages: write
@@ -35,8 +77,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    runs-on: ubuntu-latest
     steps:
-      - name: "Deploy to GitHub Pages"
+      - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1.0.6
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /site
+.venv/

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,29 @@
+# Lenient defaults for hand-written recipe markdown.
+# Cosmetic rules are off; rules that catch real rendering bugs stay on.
+default: true
+
+# --- Cosmetic / whitespace rules (off) ----------------------------------
+MD001: false  # heading increment
+MD007: false  # unordered list indent
+MD009: false  # trailing spaces
+MD010: false  # hard tabs
+MD012: false  # multiple consecutive blank lines
+MD013: false  # line length
+MD022: false  # blanks around headings
+MD024: false  # duplicate headings (recipes reuse "Ingredients" / "Directions")
+MD025: false  # single H1
+MD026: false  # trailing punctuation in headings (emoji titles)
+MD029: false  # ordered list prefix style
+MD031: false  # blanks around fenced code blocks
+MD032: false  # blanks around lists
+MD040: false  # fenced code language
+MD041: false  # first line must be h1
+MD047: false  # single trailing newline
+
+# --- Style choices (off) -------------------------------------------------
+MD004: false  # ul-style (mix of * and -)
+MD033: false  # inline HTML
+MD034: false  # bare URLs
+
+# Real bugs (MD042 no-empty-links, MD039 no-space-in-links, MD011 reversed
+# link syntax, MD018 no-missing-space-atx, etc.) remain enabled by default.

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,12 @@
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable
+  truthy:
+    allowed-values: ["true", "false", "on", "off"]
+  comments:
+    min-spaces-from-content: 1
+  indentation:
+    spaces: 2
+    indent-sequences: consistent

--- a/mkdocs.requirements
+++ b/mkdocs.requirements
@@ -1,6 +1,6 @@
-mkdocs
-mkdocs-material
-pygments
-pymdown-extensions
-mkdocs-awesome-pages-plugin
-mkdocs-git-revision-date-localized-plugin
+mkdocs>=1.6.1,<2
+mkdocs-material>=9.5.49,<10
+pygments>=2.18.0
+pymdown-extensions>=10.14
+mkdocs-awesome-pages-plugin>=2.10.1
+mkdocs-git-revision-date-localized-plugin>=1.3.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,13 +3,21 @@ site_url: https://recipes.raney.co
 repo_url: https://github.com/KevinRaney/Recipes
 edit_uri: edit/main/docs/
 repo_name: KevinRaney/Recipes
-copyright: Copyright &copy; 2024 Recipes.Raney.co
+copyright: Copyright &copy; 2026 Recipes.Raney.co
+
+plugins:
+  - search
+  - awesome-pages
+  - git-revision-date-localized:
+      enable_creation_date: true
+      type: date
+      fallback_to_build_date: true
 
 theme:
   name: 'material'
   icon:
     repo: fontawesome/brands/github
-  palette:        
+  palette:
     # Palette toggle for dark mode
     - media: "(prefers-color-scheme: dark)"
       scheme: slate
@@ -49,5 +57,6 @@ markdown_extensions:
   - pymdownx.tasklist:
       custom_checkbox: true
       clickable_checkbox: true
+
 extra:
   generator: false

--- a/readme.md
+++ b/readme.md
@@ -3,13 +3,26 @@
 Source for [recipes.raney.co](https://recipes.raney.co), built with
 [MkDocs](https://www.mkdocs.org/) + [Material](https://squidfunk.github.io/mkdocs-material/).
 
+## Prerequisites
+
+- **Python 3.12+** (CI uses 3.12 — see [.github/workflows/build_and_deploy.yml](.github/workflows/build_and_deploy.yml)). On macOS: `brew install python`.
+- **Node.js** (LTS) — only needed if you want to run the markdown linter locally via `npx`.
+
 ## Setup
 
+Homebrew's Python is PEP 668 "externally managed", so install dependencies into a virtual environment:
+
 ```sh
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r mkdocs.requirements
 ```
 
+The `.venv/` directory is gitignored. Re-activate it in new shells with `source .venv/bin/activate`; leave it with `deactivate`.
+
 ## Local Development
+
+With the venv activated:
 
 ```sh
 mkdocs serve

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,39 @@
+# Lean & Green Recipes
+
+Source for [recipes.raney.co](https://recipes.raney.co), built with
+[MkDocs](https://www.mkdocs.org/) + [Material](https://squidfunk.github.io/mkdocs-material/).
+
 ## Setup
 
-```
-pip3 install -r mkdocs.requirements
+```sh
+pip install -r mkdocs.requirements
 ```
 
 ## Local Development
+
+```sh
+mkdocs serve
 ```
-python3 -m mkdocs serve
+
+## Lint
+
+CI runs these before building. To run them locally:
+
+```sh
+# Markdown
+npx markdownlint-cli2 --config .markdownlint.yaml "docs/**/*.md" "readme.md"
+
+# YAML
+yamllint -c .yamllint.yaml mkdocs.yml .github/workflows
+
+# Strict build (fails on warnings, broken links, etc.)
+mkdocs build --strict
 ```
 
 ## Deploy
 
-```
-python3 -m mkdocs gh-deploy
+`main` deploys automatically via GitHub Actions. To deploy from a workstation:
+
+```sh
+mkdocs gh-deploy
 ```


### PR DESCRIPTION
## Summary

- **Refresh dependencies** — pin `mkdocs`, `mkdocs-material`, `pygments`, `pymdown-extensions`, `mkdocs-awesome-pages-plugin`, and `mkdocs-git-revision-date-localized-plugin` to current major versions in `mkdocs.requirements`.
- **Wire up plugins** — `awesome-pages` and `git-revision-date-localized` were listed in requirements but never enabled in `mkdocs.yml`. Now configured.
- **Modernize the workflow**:
  - Bump `actions/checkout@v1` → `v4`, `upload-pages-artifact@v1` → `v3`, `deploy-pages@v1` → `v4`
  - Add `actions/setup-python@v5` with pip caching
  - Run on PRs against `main` (not just push)
  - Build with `--strict` so warnings/broken links fail the build
  - LFS pulled via the checkout action's `lfs: true`

- **New lint stage runs first** — build/deploy only proceed if it passes:
  - `markdownlint-cli2` over `docs/**/*.md` and `readme.md`
  - `yamllint` over `mkdocs.yml` and `.github/workflows`

- **Lint configs** (`.markdownlint.yaml`, `.yamllint.yaml`) are intentionally lenient for hand-authored recipe markdown — cosmetic rules (blank lines, list indent, trailing spaces, etc.) are off, but rules that catch real rendering bugs (empty links, malformed syntax) stay on. All 285 existing recipe files pass cleanly.

- **README** updated with the local lint/build commands.

## Test plan

- [x] `pip install -r mkdocs.requirements` succeeds
- [x] `mkdocs build --strict` succeeds with the new plugins enabled
- [x] `yamllint -c .yamllint.yaml mkdocs.yml .github/workflows` is clean
- [x] `markdownlint-cli2 --config .markdownlint.yaml "docs/**/*.md" "readme.md"` is clean (0 errors across 285 files)
- [ ] CI runs the new `lint` → `build` → `deploy` chain on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lt2Zf2jUASoSwUVKPgU5ti)_