### PR TITLE
Convert remaining recipe directions to numbered lists

### DIFF
--- a/docs/appetizers/Bell-Pepper-Nachos-1.md
+++ b/docs/appetizers/Bell-Pepper-Nachos-1.md
@@ -52,7 +52,7 @@ Per serving:
 4. For the Taco seasoned beef:
 5. In a large skillet over medium heat, add meat and seasonings. Cook and break up meat until cooked thoroughly about 6 to 7 min. Drain meat of any excess fat.
 
-* If you want to use 85 to 94% lean ground beef, omit the guacamole or avocado.
+Note: If you want to use 85 to 94% lean ground beef, omit the guacamole or avocado.
 
 ![Bell Pepper Nachos-1](./Bell-Pepper-Nachos-1.png)
 

--- a/docs/appetizers/Ranch-Bacon-Cauliflower-Bites.md
+++ b/docs/appetizers/Ranch-Bacon-Cauliflower-Bites.md
@@ -22,10 +22,10 @@ fueling:
 - [ ] 1 teaspoon chives⠀
 
 ## Directions
-* Preheat oven to 375°. Pulse cauliflower in a food processor until it forms large crumbs.
-* Place cauliflower in paper towels or cheesecloth and wring out any excess water. Pour cauliflower crumbles into a large bowl.
-* Add eggs, 1 cup cheese, ranch seasoning, about 3/4s of the bacon, and chives.
-* Grease a muffin tin with cooking spray, then fill each one about 2/3s full. Top with a sprinkle of cheese and crumbled bacon. Bake for about 20 to 22 minutes, or until lightly golden. Garnish with additional chives before serving.
+1. Preheat oven to 375°. Pulse cauliflower in a food processor until it forms large crumbs.
+2. Place cauliflower in paper towels or cheesecloth and wring out any excess water. Pour cauliflower crumbles into a large bowl.
+3. Add eggs, 1 cup cheese, ranch seasoning, about 3/4s of the bacon, and chives.
+4. Grease a muffin tin with cooking spray, then fill each one about 2/3s full. Top with a sprinkle of cheese and crumbled bacon. Bake for about 20 to 22 minutes, or until lightly golden. Garnish with additional chives before serving.
 
 1. Makes 4 servings⠀
 2. Each serving provides⠀

--- a/docs/appetizers/Taco-Dip.md
+++ b/docs/appetizers/Taco-Dip.md
@@ -35,15 +35,10 @@ Per serving:
 - [ ] 1 pound mini bell peppers, sliced in half lengthwise, stems and seeds removed, for serving instead of chips
 
 ## Directions
-* Combine softened cream cheese, greek yogurt, chicken, salsa, and taco seasoning until smooth and well combined. 
-
-* Spread into a rectangle baking dish or pie plate (I used an 11"x7" baking pan). 
-
-* Refrigerate for an hour to let flavors combine (optional). 
-
-* Top with remaining ingredients. Enjoy!
+1. Combine softened cream cheese, greek yogurt, chicken, salsa, and taco seasoning until smooth and well combined.
+2. Spread into a rectangle baking dish or pie plate (I used an 11"x7" baking pan).
+3. Refrigerate for an hour to let flavors combine (optional).
+4. Top with remaining ingredients. Enjoy!
 
 ![Taco Dip](./Taco-Dip.png)
-
-* 
 

--- a/docs/hearty/Chicken/Greek-Stuffed-Chicken.md
+++ b/docs/hearty/Chicken/Greek-Stuffed-Chicken.md
@@ -42,13 +42,13 @@ Roughly 2 1/2 condiments
 - [ ] Extra dill and fresh parsley for garnish
 
 ## Directions
-* Preheat oven to 350F. Line a sheet pan with parchment paper or spray with non-stick cooking spray.
-* Place chicken on prepared sheet pan. Using a sharp knife make 5-6 slits on the back of the chicken about ¾ of the way through the chicken (careful not to slice all the way through).
-* In a small bowl, mix olive oil, lemon juice, dill, parsley, garlic and salt and pepper. Brush chicken breasts (including inside the slits) with olive oil mixture. Set aside any remaining olive oil mixture.
-* In a large bowl, add zucchini slices, yellow squash, tomato (or roasted red pepper) and red onion. Drizzle remaining olive oil mixture over vegetables and gently mix to coat.
-* Stuff the slits on the back of the chicken with zucchini, yellow squash, tomato and red onion and feta. Sprinkle mozzarella and feta on top of stuffed chicken breast.
-* Bake until chicken is cooked through (about 20-25 minutes) . If desired switch the oven from bake to broil for the last 5-10 minutes of cooking for a more bubbly and browned cheese.
-1. Garnish with additional fresh dill and parsley
+1. Preheat oven to 350F. Line a sheet pan with parchment paper or spray with non-stick cooking spray.
+2. Place chicken on prepared sheet pan. Using a sharp knife make 5-6 slits on the back of the chicken about ¾ of the way through the chicken (careful not to slice all the way through).
+3. In a small bowl, mix olive oil, lemon juice, dill, parsley, garlic and salt and pepper. Brush chicken breasts (including inside the slits) with olive oil mixture. Set aside any remaining olive oil mixture.
+4. In a large bowl, add zucchini slices, yellow squash, tomato (or roasted red pepper) and red onion. Drizzle remaining olive oil mixture over vegetables and gently mix to coat.
+5. Stuff the slits on the back of the chicken with zucchini, yellow squash, tomato and red onion and feta. Sprinkle mozzarella and feta on top of stuffed chicken breast.
+6. Bake until chicken is cooked through (about 20-25 minutes) . If desired switch the oven from bake to broil for the last 5-10 minutes of cooking for a more bubbly and browned cheese.
+7. Garnish with additional fresh dill and parsley
 
 ![Greek Stuffed Chicken](./Greek-Stuffed-Chicken.png)
 

--- a/docs/hearty/Seafood/Cilantro-Lime-Shrimp-Wraps.md
+++ b/docs/hearty/Seafood/Cilantro-Lime-Shrimp-Wraps.md
@@ -30,17 +30,15 @@ fueling:
 - [ ] 1/4 c. Sour cream, for serving (2 healthy fats)
 
 ## Directions
-* In a large bowl, stir together shrimp, cumin, lime juice, cilantro, garlic, and 1 tsp oil and season with salt and pepper. Toss until combined, then let marinate in the fridge 10 minutes.
+1. In a large bowl, stir together shrimp, cumin, lime juice, cilantro, garlic, and 1 tsp oil and season with salt and pepper. Toss until combined, then let marinate in the fridge 10 minutes.
+2. In a large skillet over medium heat, heat remaining tsp oil. Add shrimp and marinade cook until pink, 2 minutes per side.
+3. Assemble wraps: Add shrimp and avocado to lettuce, drizzle with sour cream, and garnish with cilantro.
 
-* In a large skillet over medium heat, heat remaining tsp oil. Add shrimp and marinade cook until pink, 2 minutes per side.
-
-* Assemble wraps: Add shrimp and avocado to lettuce, drizzle with sour cream, and garnish with cilantro. 
-
-1. Makes 3 servings:
-2. 1 leanest
-3. ~3 condiments
-4. 2 healthy fats
-5. 2 greens
+Makes 3 servings:
+- 1 leanest
+- ~3 condiments
+- 2 healthy fats
+- 2 greens
 
 ![Cilantro-Lime Shrimp Wraps](./Cilantro-Lime-Shrimp-Wraps.png)
 


### PR DESCRIPTION
## Summary
- Converted bulleted Directions sections to numbered (ordered) lists across 5 recipes for consistency.
- Affected files: `Ranch-Bacon-Cauliflower-Bites.md`, `Taco-Dip.md`, `Bell-Pepper-Nachos-1.md`, `Greek-Stuffed-Chicken.md`, `Cilantro-Lime-Shrimp-Wraps.md`.
- For `Bell-Pepper-Nachos-1.md` the trailing bullet was a side note (not a step), so it was rewritten as a "Note:" line. For `Cilantro-Lime-Shrimp-Wraps.md` the trailing numbered list described per-serving fueling info and was changed to an unordered list to keep it distinct from the actual steps.

## Test plan
- [ ] Visual check that Directions render as ordered lists on the rendered site.
- [ ] `zensical build -s` passes in CI.

https://claude.ai/code/session_012bdy7rUuWxfxa1AH4e4j9M

---
_Generated by [Claude Code](https://claude.ai/code/session_012bdy7rUuWxfxa1AH4e4j9M)_