### PR TITLE
Add Lean & Green nutrition badge generator

### DIFF
--- a/docs/Tips-and-Hacks/index.md
+++ b/docs/Tips-and-Hacks/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Tips & Hacks"
-description: "All Lean & Green tips & hacks recipes (4 total)."
+description: "All Lean & Green tips & hacks recipes (5 total)."
 tags:
   - overview
   - tip
@@ -11,9 +11,10 @@ hide:
 
 Cheats, swaps, and shopping notes that make Lean & Green easier.
 
-_4 recipes._
+_5 recipes._
 
 - [Brownie Treat](BrownieTreat/)
 - [Cheese](Cheese/)
 - [Green Chili “fueling hack”](Green-Chili-fueling-hack/)
+- [Tips & Hacks](index/)
 - [Trader Joe’s Grocery List](Trader-Joes-Grocery-List/)

--- a/docs/appetizers/AirFriedCoconutShrimp.md
+++ b/docs/appetizers/AirFriedCoconutShrimp.md
@@ -6,12 +6,31 @@ tags:
   - air-fryer
   - shrimp
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Air Fried Coconut Shrimp
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 9 ounces raw shrimp, shell and tails removed (1 Leanest Lean)

--- a/docs/appetizers/Avocado-salsa.md
+++ b/docs/appetizers/Avocado-salsa.md
@@ -4,11 +4,31 @@ description: "Avocado salsa - Lean & Green appetizer."
 tags:
   - appetizer
 servings: 16
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2.5
+  snack: 0
 ---
 # Avocado salsa
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 # Avocado salsa
 

--- a/docs/appetizers/Bell-Pepper-Nachos-1.md
+++ b/docs/appetizers/Bell-Pepper-Nachos-1.md
@@ -4,13 +4,31 @@ description: "Bell Pepper Nachos - Lean & Green appetizer."
 tags:
   - appetizer
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.5
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 1
 ---
 # Bell Pepper Nachos
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Servings

--- a/docs/appetizers/Bell-Pepper-Nachos.md
+++ b/docs/appetizers/Bell-Pepper-Nachos.md
@@ -4,13 +4,31 @@ description: "Bell Pepper Nachos - Lean & Green appetizer."
 tags:
   - appetizer
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Bell Pepper Nachos
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 1 serving:
 1 lean 

--- a/docs/appetizers/Buffalo-Chicken-Appetizer.md
+++ b/docs/appetizers/Buffalo-Chicken-Appetizer.md
@@ -5,12 +5,31 @@ tags:
   - appetizer
   - american
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Buffalo Chicken Appetizer
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 Servings!
 Per Serving:

--- a/docs/appetizers/Cauliflower-Ranch-Chips.md
+++ b/docs/appetizers/Cauliflower-Ranch-Chips.md
@@ -6,11 +6,31 @@ tags:
   - cauliflower
   - american
 servings: 7
-fueling:
-  condiments: 3
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1.75
+  condiments: 3
+  snack: 0
 ---
 # Cauliflower Ranch Chips
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 cup (16 tbsp) grated parmesan cheese (16 condiments)

--- a/docs/appetizers/Louisiana-Hot-Crab-Dip.md
+++ b/docs/appetizers/Louisiana-Hot-Crab-Dip.md
@@ -6,11 +6,31 @@ tags:
   - crab
   - dip
 servings: 7
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Louisiana Hot Crab Dip
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 7 servings and per serving you receive:
 3 condiments | 1 healthy fat | 1oz of leanest protein

--- a/docs/appetizers/Ranch-Bacon-Cauliflower-Bites.md
+++ b/docs/appetizers/Ranch-Bacon-Cauliflower-Bites.md
@@ -6,12 +6,31 @@ tags:
   - cauliflower
   - american
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 0.75
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Ranch Bacon Cauliflower Bites
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.75 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.75 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.75 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 cups (14.08 oz) fresh cauliflower (8 greens)

--- a/docs/appetizers/Ricotta-Bacon-Stuffed-Mini-Peppers.md
+++ b/docs/appetizers/Ricotta-Bacon-Stuffed-Mini-Peppers.md
@@ -6,12 +6,31 @@ tags:
   - italian
   - stuffed
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 0.5
-  condiments: 1.5
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1.5
+  condiments: 1.5
+  snack: 0
 ---
 # Ricotta Bacon Stuffed Mini Peppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 pound assorted mini peppers, about 18 mini peppers* (6 Greens)

--- a/docs/appetizers/Taco-Dip.md
+++ b/docs/appetizers/Taco-Dip.md
@@ -5,12 +5,31 @@ tags:
   - appetizer
   - mexican
   - dip
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 1
+  condiments: 2
+  snack: 0
 ---
 # Taco Dip
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Servings: 12
 

--- a/docs/appetizers/index.md
+++ b/docs/appetizers/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Appetizers"
-description: "All Lean & Green appetizers recipes (10 total)."
+description: "All Lean & Green appetizers recipes (11 total)."
 tags:
   - overview
   - appetizer
@@ -11,9 +11,10 @@ hide:
 
 Small bites and starters that fit Lean & Green.
 
-_10 recipes._
+_11 recipes._
 
 - [Air Fried Coconut Shrimp](AirFriedCoconutShrimp/)
+- [Appetizers](index/)
 - [Avocado salsa](Avocado-salsa/)
 - [Bell Pepper Nachos](Bell-Pepper-Nachos-1/)
 - [Bell Pepper Nachos](Bell-Pepper-Nachos/)

--- a/docs/browse/by-method.md
+++ b/docs/browse/by-method.md
@@ -17,17 +17,19 @@ Recipes grouped by primary cooking method. Many recipes work multiple ways - lis
 - [Bang Bang Shrimp](../hearty/Seafood/Bang-Bang-Shrimp/)
 - [Blackened Salmon Cauliflower Asparagus soup](../hearty/Seafood/Blackened-Salmon-Cauliflower-Asparagus-soup/)
 
-## Instant Pot (2)
+## Instant Pot (3)
 
 - [Barbacoa Beef](../hearty/Beef/Barbacoa-Beef/)
 - [Instant Pot Chipotle Chicken & Cauliflower Rice Bowls](../hearty/Chicken/Instant-Pot-Chipotle-Chicken-Cauliflower-Rice-Bowls/)
+- [Mains](../hearty/index/)
 
-## Pressure cooker (2)
+## Pressure cooker (3)
 
 - [Barbacoa Beef](../hearty/Beef/Barbacoa-Beef/)
+- [Mains](../hearty/index/)
 - [Pressure Cooker Lemon Olive Chicken](../hearty/Chicken/Pressure-Cooker-Lemon-Olive-Chicken/)
 
-## Slow cooker / crockpot (13)
+## Slow cooker / crockpot (15)
 
 - [Carne Guisada](../hearty/Beef/Carne-Guisada/)
 - [Crock Pot Beef Soup](../soups/This-weather-call-for-some-soup/)
@@ -35,11 +37,13 @@ Recipes grouped by primary cooking method. Many recipes work multiple ways - lis
 - [Crockpot Chicken Taco Soup](../soups/CrockpotChickenTacoSoup/)
 - [Crockpot Gumbo](../soups/Crockpot-Gumbo/)
 - [Crockpot Taco Soup](../soups/Crockpot-Taco-Soup/)
+- [Mains](../hearty/index/)
 - [Mexican Style Shredded Pork](../hearty/Pork/Mexican-Style-Shredded-Pork/)
 - [Rotisserie Style Chicken in the Slow Cooker](../hearty/Chicken/Rotisserie-Style-Chicken-in-the-Slow-Cooker/)
 - [Savory Brisket](../hearty/Beef/Savory-Brisket/)
 - [Slow Cooker Cashew Chicken](../hearty/Chicken/Slow-Cooker-Cashew-Chicken/)
 - [Slow Cooker Mushroom Soup](../soups/Slow-Cooker-Mushroom-Soup/)
+- [Soups](../soups/index/)
 - [Taste of Thai Crock Pot Chicken](../hearty/Chicken/Taste-of-Thai-Crock-Pot-Chicken/)
 - [Turkey Chili](../soups/TurkeyChili/)
 

--- a/docs/hearty/Beef/Barbacoa-Beef.md
+++ b/docs/hearty/Beef/Barbacoa-Beef.md
@@ -8,11 +8,31 @@ tags:
   - pressure-cooker
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Barbacoa Beef
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving: 1 lean protein, ¼ green, 3 condiments

--- a/docs/hearty/Beef/Beef-Pad-Thai-Spaghetti-Squash.md
+++ b/docs/hearty/Beef/Beef-Pad-Thai-Spaghetti-Squash.md
@@ -7,12 +7,31 @@ tags:
   - spaghetti-squash
   - asian
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1.4
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1.4
+  snack: 1
 ---
 # Beef Pad Thai (Spaghetti Squash)
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 3 servings, per serving you enjoy:
 1 Lean | 3 Greens | 1.4 Condiments | 1 Snack

--- a/docs/hearty/Beef/Big-Mac-lettuce-Wrap.md
+++ b/docs/hearty/Beef/Big-Mac-lettuce-Wrap.md
@@ -6,13 +6,31 @@ tags:
   - beef
   - wraps
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 1
+  condiments: 3
+  snack: 0.5
 ---
 # Big Mac lettuce Wrap
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 1 serving!
 1 leaner

--- a/docs/hearty/Beef/Carne-Guisada.md
+++ b/docs/hearty/Beef/Carne-Guisada.md
@@ -7,12 +7,31 @@ tags:
   - slow-cooker
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Carne Guisada
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving: 1 lean, 1 green, 3 condiments

--- a/docs/hearty/Beef/Cheese-Shell-Tacos.md
+++ b/docs/hearty/Beef/Cheese-Shell-Tacos.md
@@ -5,11 +5,31 @@ tags:
   - main
   - beef
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Cheese Shell Tacos
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 6 Servings

--- a/docs/hearty/Beef/Cheeseburger-Casserole-1.md
+++ b/docs/hearty/Beef/Cheeseburger-Casserole-1.md
@@ -7,10 +7,31 @@ tags:
   - cauliflower
   - casserole
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Cheeseburger Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Beef/Cheeseburger-Casserole.md
+++ b/docs/hearty/Beef/Cheeseburger-Casserole.md
@@ -7,11 +7,31 @@ tags:
   - cauliflower
   - casserole
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Cheeseburger Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 5 servings
 

--- a/docs/hearty/Beef/Cheesy-Enchilada-Stuffed-Peppers.md
+++ b/docs/hearty/Beef/Cheesy-Enchilada-Stuffed-Peppers.md
@@ -8,12 +8,31 @@ tags:
   - mexican
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cheesy Enchilada Stuffed Peppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Beef/Chili-Crusted-Tri-Tip-Roast.md
+++ b/docs/hearty/Beef/Chili-Crusted-Tri-Tip-Roast.md
@@ -6,11 +6,31 @@ tags:
   - beef
   - oven
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Chili-Crusted Tri-Tip Roast
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 4 Servings
 1 Lean | 3 Condiments.

--- a/docs/hearty/Beef/Inside-Outside-Egg-Rolls.md
+++ b/docs/hearty/Beef/Inside-Outside-Egg-Rolls.md
@@ -4,13 +4,31 @@ description: "Inside Outside Egg Rolls - Lean & Green main featuring beef."
 tags:
   - main
   - beef
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 0.5
+  condiments: 3
+  snack: 0
 ---
 # Inside Outside Egg Rolls
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 cup cabbage, shredded (2 Greens)

--- a/docs/hearty/Beef/Italian-Meaty-Casserole.md
+++ b/docs/hearty/Beef/Italian-Meaty-Casserole.md
@@ -7,11 +7,31 @@ tags:
   - italian
   - casserole
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 0.75
+  condiments: 0
+  snack: 0
 ---
 # Italian Meaty Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 Serving

--- a/docs/hearty/Beef/Lasagna.md
+++ b/docs/hearty/Beef/Lasagna.md
@@ -5,12 +5,31 @@ tags:
   - main
   - beef
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1.6
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 1.6
+  snack: 0
 ---
 # Lasagna
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.6</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 Serving

--- a/docs/hearty/Beef/Mexican-Beef-Egg-Burrito.md
+++ b/docs/hearty/Beef/Mexican-Beef-Egg-Burrito.md
@@ -6,13 +6,31 @@ tags:
   - beef
   - mexican
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.5
-  condiments: 1.75
   greens: 0.5
+  condiments: 1.75
+  snack: 0
 ---
 # Mexican Beef Egg Burrito
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 serving

--- a/docs/hearty/Beef/Mexican-Beef-and-Zucchini-Skillet.md
+++ b/docs/hearty/Beef/Mexican-Beef-and-Zucchini-Skillet.md
@@ -8,12 +8,31 @@ tags:
   - zucchini
   - mexican
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Mexican Beef and Zucchini Skillet
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Beef/Mexican-Mac-and-Cheese-1.md
+++ b/docs/hearty/Beef/Mexican-Mac-and-Cheese-1.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Mexican Mac and Cheese
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 Servings

--- a/docs/hearty/Beef/Mexican-Mac-and-Cheese-2.md
+++ b/docs/hearty/Beef/Mexican-Mac-and-Cheese-2.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Mexican Mac and Cheese
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 

--- a/docs/hearty/Beef/Mexican-Mac-and-Cheese.md
+++ b/docs/hearty/Beef/Mexican-Mac-and-Cheese.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Mexican Mac and Cheese
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 7.5 oz cooked 93% lean ground beef, fat drained (1 1/2 Leans)

--- a/docs/hearty/Beef/Mini-BBQ-Cheddar-Meatloaf.md
+++ b/docs/hearty/Beef/Mini-BBQ-Cheddar-Meatloaf.md
@@ -7,12 +7,31 @@ tags:
   - american
   - meatballs
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Mini BBQ Cheddar Meatloaf
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 5 servings
 

--- a/docs/hearty/Beef/Mongolian-Beef-over-Cauliflower-Rice.md
+++ b/docs/hearty/Beef/Mongolian-Beef-over-Cauliflower-Rice.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Mongolian Beef over Cauliflower Rice
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 pound raw beef round steak, cut into strips - you want 10 oz cooked (2 leans)

--- a/docs/hearty/Beef/Parmesan-Meatloaf-Gluten-Free.md
+++ b/docs/hearty/Beef/Parmesan-Meatloaf-Gluten-Free.md
@@ -7,11 +7,31 @@ tags:
   - italian
   - meatballs
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Parmesan Meatloaf (Gluten Free)
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Each serving provides: 1 lean, 2 condiments, ½ green

--- a/docs/hearty/Beef/Philly-Cheesesteak-Casserole.md
+++ b/docs/hearty/Beef/Philly-Cheesesteak-Casserole.md
@@ -7,12 +7,31 @@ tags:
   - american
   - casserole
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 2
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 2
+  snack: 0
 ---
 # Philly Cheesesteak Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Each  1 leaner + 1 green + 2/3 fat + 2 condiments

--- a/docs/hearty/Beef/Philly-Steak-Cheese-Skillet.md
+++ b/docs/hearty/Beef/Philly-Steak-Cheese-Skillet.md
@@ -7,12 +7,32 @@ tags:
   - stovetop
   - american
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1.5
+  condiments: 3
+  snack: 0
 ---
 # Philly Steak Cheese Skillet
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 Makes 5 servings
 1 Lean
 1 1/2 Green

--- a/docs/hearty/Beef/PhillyCheesesteakPeppers.md
+++ b/docs/hearty/Beef/PhillyCheesesteakPeppers.md
@@ -7,13 +7,31 @@ tags:
   - american
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 2
+  condiments: 2
+  snack: 0
 ---
 # Philly Cheesesteak Stuffed Peppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Yields
 4 Servings, 1 Lean, 2 Green, 1 Healthy Fat, 2 Condiments

--- a/docs/hearty/Beef/Savory-Brisket.md
+++ b/docs/hearty/Beef/Savory-Brisket.md
@@ -6,11 +6,31 @@ tags:
   - beef
   - slow-cooker
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Savory Brisket
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving

--- a/docs/hearty/Beef/Shepherds-Pie.md
+++ b/docs/hearty/Beef/Shepherds-Pie.md
@@ -5,12 +5,31 @@ tags:
   - main
   - beef
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 0.75
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 0.75
+  condiments: 0.75
+  snack: 0
 ---
 # Shepherd's Pie
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Beef/Simple-Beef-with-Broccoli-Stir-Fry.md
+++ b/docs/hearty/Beef/Simple-Beef-with-Broccoli-Stir-Fry.md
@@ -8,12 +8,31 @@ tags:
   - cauliflower
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Simple Beef with Broccoli Stir Fry
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 servings

--- a/docs/hearty/Beef/Skillet-Steak-Fajitas.md
+++ b/docs/hearty/Beef/Skillet-Steak-Fajitas.md
@@ -6,12 +6,31 @@ tags:
   - beef
   - stovetop
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Skillet Steak Fajitas
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 1 serving:
 1 lean

--- a/docs/hearty/Beef/Sloppy-Joes-with-Revolution-Rolls.md
+++ b/docs/hearty/Beef/Sloppy-Joes-with-Revolution-Rolls.md
@@ -5,11 +5,31 @@ tags:
   - main
   - beef
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Sloppy Joes with Revolution Rolls
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 3 servings

--- a/docs/hearty/Beef/Sour-Cream-Beef-Bake.md
+++ b/docs/hearty/Beef/Sour-Cream-Beef-Bake.md
@@ -7,12 +7,31 @@ tags:
   - oven
   - cauliflower
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Sour Cream Beef Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 

--- a/docs/hearty/Beef/Steak-and-Zucchini-Horseradish-Alfredo.md
+++ b/docs/hearty/Beef/Steak-and-Zucchini-Horseradish-Alfredo.md
@@ -6,12 +6,31 @@ tags:
   - beef
   - zucchini
   - italian
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2.25
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2.25
+  snack: 0
 ---
 # Steak and Zucchini Horseradish Alfredo
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Serves 4
 Per serving: 3 green, 1 lean, ~2.25 condiments

--- a/docs/hearty/Beef/Stuffed-Cheesy-Meatballs.md
+++ b/docs/hearty/Beef/Stuffed-Cheesy-Meatballs.md
@@ -6,11 +6,31 @@ tags:
   - beef
   - stuffed
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Stuffed Cheesy Meatballs
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 1 servings
 Per serving: 1 lean, 3 condiments

--- a/docs/hearty/Beef/Swedish-Meatballs-with-Zucchini-Ribbons-1.md
+++ b/docs/hearty/Beef/Swedish-Meatballs-with-Zucchini-Ribbons-1.md
@@ -6,12 +6,31 @@ tags:
   - beef
   - zucchini
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Swedish Meatballs with Zucchini Ribbons
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Beef/Swedish-Meatballs-with-Zucchini-Ribbons.md
+++ b/docs/hearty/Beef/Swedish-Meatballs-with-Zucchini-Ribbons.md
@@ -6,12 +6,31 @@ tags:
   - beef
   - zucchini
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Swedish Meatballs with Zucchini Ribbons
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Beef/TACO-STUFFED-TOMATOES.md
+++ b/docs/hearty/Beef/TACO-STUFFED-TOMATOES.md
@@ -7,11 +7,31 @@ tags:
   - mexican
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # TACO STUFFED TOMATOES
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] ½ cup scallions

--- a/docs/hearty/Beef/TERIYAKI-BEEF-ASPARAGUS-SKEWERS.md
+++ b/docs/hearty/Beef/TERIYAKI-BEEF-ASPARAGUS-SKEWERS.md
@@ -6,12 +6,31 @@ tags:
   - beef
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # TERIYAKI BEEF ASPARAGUS SKEWERS
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 

--- a/docs/hearty/Beef/Taco-Beef-and-Zucchini-Skillet.md
+++ b/docs/hearty/Beef/Taco-Beef-and-Zucchini-Skillet.md
@@ -7,12 +7,31 @@ tags:
   - stovetop
   - zucchini
   - mexican
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Taco Beef and Zucchini Skillet
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 1 Serving
 

--- a/docs/hearty/Beef/Three-Mini-Zucchini-Sliders.md
+++ b/docs/hearty/Beef/Three-Mini-Zucchini-Sliders.md
@@ -5,10 +5,31 @@ tags:
   - main
   - beef
   - zucchini
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Three Mini Zucchini Sliders
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 (1 Complete Lean & Green w/3 condiments)
 

--- a/docs/hearty/Beef/Unstuffed-Cabbage.md
+++ b/docs/hearty/Beef/Unstuffed-Cabbage.md
@@ -5,12 +5,31 @@ tags:
   - main
   - beef
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1.7
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1.7
+  snack: 0
 ---
 # Unstuffed Cabbage
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.7</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 25 oz 93% lean ground beef, cooked (5 Leans)

--- a/docs/hearty/Chicken/Alice-Springs-Chicken.md
+++ b/docs/hearty/Chicken/Alice-Springs-Chicken.md
@@ -5,13 +5,31 @@ tags:
   - main
   - chicken
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 2.25
   greens: 1
+  condiments: 2.25
+  snack: 0
 ---
 # Alice Springs Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Chicken/Almond-Maple-Chicken.md
+++ b/docs/hearty/Chicken/Almond-Maple-Chicken.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Almond Maple Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 9 oz raw chicken breasts - should yield 6 oz cooked (1 Lean) 

--- a/docs/hearty/Chicken/Asparagus-Stuffed-Chicken-Breast.md
+++ b/docs/hearty/Chicken/Asparagus-Stuffed-Chicken-Breast.md
@@ -5,8 +5,31 @@ tags:
   - main
   - chicken
   - stuffed
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Asparagus Stuffed Chicken Breast
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 Skinless boneless chicken breasts about 1 1/2 lb. 

--- a/docs/hearty/Chicken/BBQ-Ranch-Chicken-Salad-Sandwich.md
+++ b/docs/hearty/Chicken/BBQ-Ranch-Chicken-Salad-Sandwich.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
   - american
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2.4
+  snack: 0
 ---
 # BBQ Ranch Chicken Salad Sandwich
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 1 Serving
 Per Serving: 1 Lean, 1 healthy fat, 2.4 Condiments

--- a/docs/hearty/Chicken/Baked-Garlic-Cheddar-Chicken.md
+++ b/docs/hearty/Chicken/Baked-Garlic-Cheddar-Chicken.md
@@ -6,12 +6,32 @@ tags:
   - chicken
   - oven
 servings: 8
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Baked Garlic Cheddar Chicken 
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 Makes 8 servings
 Per serving
 1 Leaner | 1 Healthy Fat | ~3 Condiments

--- a/docs/hearty/Chicken/Balsamic-Chicken-Peppers.md
+++ b/docs/hearty/Chicken/Balsamic-Chicken-Peppers.md
@@ -5,13 +5,32 @@ tags:
   - main
   - chicken
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Balsamic Chicken & Peppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 Makes 4 servings
 Per serving:
 1 Lean

--- a/docs/hearty/Chicken/Braised-Balsamic-Chicken.md
+++ b/docs/hearty/Chicken/Braised-Balsamic-Chicken.md
@@ -5,11 +5,31 @@ tags:
   - main
   - chicken
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Braised Balsamic Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 6 skinless, boneless chicken breast halves – total weight 3 1/3 pounds

--- a/docs/hearty/Chicken/Broccoli-and-Cheese-Stuffed-Chicken.md
+++ b/docs/hearty/Chicken/Broccoli-and-Cheese-Stuffed-Chicken.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - stuffed
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2.33
+  snack: 0
 ---
 # Broccoli and Cheese Stuffed Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Chicken/Buffalo-Chicken-Spaghetti-Squash-Boats.md
+++ b/docs/hearty/Chicken/Buffalo-Chicken-Spaghetti-Squash-Boats.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - spaghetti-squash
   - american
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Buffalo Chicken Spaghetti Squash Boats
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 medium spaghetti squash, cooked and shredded

--- a/docs/hearty/Chicken/Buffalo-Chicken-Stuffed-Peppers.md
+++ b/docs/hearty/Chicken/Buffalo-Chicken-Stuffed-Peppers.md
@@ -7,12 +7,31 @@ tags:
   - american
   - stuffed
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1.6
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1.6
+  snack: 0
 ---
 # Buffalo Chicken Stuffed Peppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.6</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 12 ounces cooked chicken breasts, chopped or shredded 

--- a/docs/hearty/Chicken/Buffalo-Chicken-Wraps-1.md
+++ b/docs/hearty/Chicken/Buffalo-Chicken-Wraps-1.md
@@ -7,12 +7,31 @@ tags:
   - american
   - wraps
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 1.25
+  condiments: 3
+  snack: 0
 ---
 # Buffalo Chicken Wraps
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 1/2 cups low-fat Greek yogurt (1 leaner)

--- a/docs/hearty/Chicken/Buffalo-Chicken-Wraps.md
+++ b/docs/hearty/Chicken/Buffalo-Chicken-Wraps.md
@@ -7,12 +7,31 @@ tags:
   - american
   - wraps
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 1.25
+  condiments: 3
+  snack: 0
 ---
 # Buffalo Chicken Wraps
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 1/2 cups low-fat Greek yogurt (1 leaner)

--- a/docs/hearty/Chicken/Buffalo-Chikn-Bake.md
+++ b/docs/hearty/Chicken/Buffalo-Chikn-Bake.md
@@ -8,12 +8,31 @@ tags:
   - cauliflower
   - american
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Buffalo Chik'n Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 # Buffalo Chik'n Bake
 

--- a/docs/hearty/Chicken/Bunless-Chicken-BLTs.md
+++ b/docs/hearty/Chicken/Bunless-Chicken-BLTs.md
@@ -5,10 +5,31 @@ tags:
   - main
   - chicken
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Bunless Chicken BLTs
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Pre-Prepare (Optional)
 To cook the chicken breasts ahead, you’ll only need to set aside about 15 minutes earlier in the week. 

--- a/docs/hearty/Chicken/California-Club-Tacos.md
+++ b/docs/hearty/Chicken/California-Club-Tacos.md
@@ -5,13 +5,31 @@ tags:
   - main
   - chicken
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # California Club Tacos
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 Serving: 1 leaner | 3 greens | 1 healthy fat | 1 condiment
 

--- a/docs/hearty/Chicken/Caprese-Chicken-Stuffed-Peppers.md
+++ b/docs/hearty/Chicken/Caprese-Chicken-Stuffed-Peppers.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - italian
   - stuffed
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 1.5
   greens: 3
+  condiments: 1.5
+  snack: 0
 ---
 # Caprese Chicken Stuffed Peppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 # Caprese Chicken Stuffed Peppers
 

--- a/docs/hearty/Chicken/Cauliflower-Crust-Pot-Pie.md
+++ b/docs/hearty/Chicken/Cauliflower-Crust-Pot-Pie.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - cauliflower
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cauliflower Crust Pot Pie
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Each serving provides:

--- a/docs/hearty/Chicken/Cauliflower-Mexican-Rice-with-Chicken.md
+++ b/docs/hearty/Chicken/Cauliflower-Mexican-Rice-with-Chicken.md
@@ -7,13 +7,31 @@ tags:
   - cauliflower
   - mexican
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cauliflower Mexican Rice with Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 # Cauliflower Mexican Rice with Chicken
 

--- a/docs/hearty/Chicken/Cauliflower-Pizza-with-Chicken-Tzatziki.md
+++ b/docs/hearty/Chicken/Cauliflower-Pizza-with-Chicken-Tzatziki.md
@@ -7,13 +7,31 @@ tags:
   - cauliflower
   - mediterranean
   - pizza
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Cauliflower Pizza with Chicken & Tzatziki
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 4 servings
 Complete Lean & Green Meal: 1 leaner, 1 healthy fat, 3 green, 1 condiment

--- a/docs/hearty/Chicken/Cheesy-Chicken-Spaghetti-Squash-Casserole.md
+++ b/docs/hearty/Chicken/Cheesy-Chicken-Spaghetti-Squash-Casserole.md
@@ -7,13 +7,31 @@ tags:
   - spaghetti-squash
   - casserole
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.5
-  condiments: 2.8
   greens: 3
+  condiments: 2.8
+  snack: 0
 ---
 # Cheesy Chicken Spaghetti Squash Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.8</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Chicken/Cheesy-Italian-Chicken-Spaghetti-Squash-Casserole-1.md
+++ b/docs/hearty/Chicken/Cheesy-Italian-Chicken-Spaghetti-Squash-Casserole-1.md
@@ -7,13 +7,32 @@ tags:
   - spaghetti-squash
   - italian
   - casserole
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cheesy Italian Chicken Spaghetti Squash Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 ⁪
 Yields: 1 Serving
 Pre serving: 1 Lean|3 Greens|3 Condiments|1 Healthy Fat

--- a/docs/hearty/Chicken/Cheesy-Italian-Chicken-Spaghetti-Squash-Casserole.md
+++ b/docs/hearty/Chicken/Cheesy-Italian-Chicken-Spaghetti-Squash-Casserole.md
@@ -8,13 +8,31 @@ tags:
   - italian
   - casserole
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cheesy Italian Chicken Spaghetti Squash Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 cup (5.46 oz) prepared Spaghetti Squash (2 greens)

--- a/docs/hearty/Chicken/Chicken-Alfredo-and-Spinach-Pizza.md
+++ b/docs/hearty/Chicken/Chicken-Alfredo-and-Spinach-Pizza.md
@@ -8,13 +8,31 @@ tags:
   - italian
   - pizza
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Chicken Alfredo and Spinach "Pizza"
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Chicken/Chicken-Bacon-Ranch-Lettuce-Wraps.md
+++ b/docs/hearty/Chicken/Chicken-Bacon-Ranch-Lettuce-Wraps.md
@@ -7,12 +7,31 @@ tags:
   - american
   - wraps
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 0.5
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 0.5
+  snack: 0
 ---
 # Chicken Bacon Ranch Lettuce Wraps 
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] Non-stick pan spray

--- a/docs/hearty/Chicken/Chicken-Cacciatore-and-Spaghetti-Squash.md
+++ b/docs/hearty/Chicken/Chicken-Cacciatore-and-Spaghetti-Squash.md
@@ -7,10 +7,31 @@ tags:
   - spaghetti-squash
   - italian
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2.67
+  snack: 0
 ---
 # Chicken Cacciatore and Spaghetti Squash
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.67</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving

--- a/docs/hearty/Chicken/Chicken-Cilantro-Stuffed-Mushrooms.md
+++ b/docs/hearty/Chicken/Chicken-Cilantro-Stuffed-Mushrooms.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - stuffed
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2.5
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2.5
+  snack: 0
 ---
 # Chicken Cilantro Stuffed Mushrooms
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 serving
 1 lean

--- a/docs/hearty/Chicken/Chicken-Egg-Foo-Young.md
+++ b/docs/hearty/Chicken/Chicken-Egg-Foo-Young.md
@@ -5,13 +5,31 @@ tags:
   - main
   - chicken
   - zucchini
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1.5
-  condiments: 1.75
   greens: 3
+  condiments: 1.75
+  snack: 0
 ---
 # Chicken Egg Foo Young
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1.5 teaspoon sesame oil, divided (1.5 Healthy Fats)

--- a/docs/hearty/Chicken/Chicken-Parmesan.md
+++ b/docs/hearty/Chicken/Chicken-Parmesan.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
   - italian
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Chicken Parmesan
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 2 Servings
 

--- a/docs/hearty/Chicken/Chicken-Pesto-Bake.md
+++ b/docs/hearty/Chicken/Chicken-Pesto-Bake.md
@@ -7,12 +7,31 @@ tags:
   - oven
   - italian
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 0.5
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 0.5
+  snack: 0
 ---
 # Chicken Pesto Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 Per serving

--- a/docs/hearty/Chicken/Chicken-Pesto-Roll-Ups.md
+++ b/docs/hearty/Chicken/Chicken-Pesto-Roll-Ups.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - italian
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 1
+  condiments: 1
+  snack: 0
 ---
 # Chicken Pesto Roll-Ups
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Each serving provides:

--- a/docs/hearty/Chicken/Chicken-Scampi-with-Arugula.md
+++ b/docs/hearty/Chicken/Chicken-Scampi-with-Arugula.md
@@ -6,15 +6,31 @@ tags:
   - chicken
   - zucchini
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 4
-  condiments: 3
   greens: 0.5
+  condiments: 3
+  snack: 0
 ---
 # Chicken Scampi with Arugula
 
- 
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings 
 

--- a/docs/hearty/Chicken/Chicken-Stuffed-with-Spinach-Goat-Cheese-Pine-Nuts-1.md
+++ b/docs/hearty/Chicken/Chicken-Stuffed-with-Spinach-Goat-Cheese-Pine-Nuts-1.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Chicken Stuffed with Spinach, Goat Cheese & Pine Nuts
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Each serving provides:

--- a/docs/hearty/Chicken/Chicken-Stuffed-with-Spinach-Goat-Cheese-Pine-Nuts.md
+++ b/docs/hearty/Chicken/Chicken-Stuffed-with-Spinach-Goat-Cheese-Pine-Nuts.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Chicken Stuffed with Spinach, Goat Cheese & Pine Nuts
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Each serving provides:

--- a/docs/hearty/Chicken/Chicken-Zucchini-Poppers.md
+++ b/docs/hearty/Chicken/Chicken-Zucchini-Poppers.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - zucchini
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Chicken Zucchini Poppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 2 servings with each:
 1 leaner

--- a/docs/hearty/Chicken/Chicken-Zucchini-Stir-Fry.md
+++ b/docs/hearty/Chicken/Chicken-Zucchini-Stir-Fry.md
@@ -8,12 +8,31 @@ tags:
   - zucchini
   - asian
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 1
 ---
 # Chicken Zucchini Stir-Fry
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Chicken/Chicken-hearts-of-palm-spinach-and-Alfredo-pizza-on-a-spaghetti….md
+++ b/docs/hearty/Chicken/Chicken-hearts-of-palm-spinach-and-Alfredo-pizza-on-a-spaghetti….md
@@ -8,12 +8,31 @@ tags:
   - italian
   - pizza
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Chicken, hearts of palm, spinach and Alfredo pizza on a spaghetti squash crust
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Serving Size: 1/4 Pizza

--- a/docs/hearty/Chicken/Chicken-with-Chipotle-Mushroom-Cream-Sauce.md
+++ b/docs/hearty/Chicken/Chicken-with-Chipotle-Mushroom-Cream-Sauce.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - mexican
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 1.5
+  condiments: 2
+  snack: 0
 ---
 # Chicken with Chipotle Mushroom Cream Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 18 oz Raw Chicken Breasts - should yield 12 oz cooked (2 Leaner)

--- a/docs/hearty/Chicken/Chile-Chicken-Verde-Casserole.md
+++ b/docs/hearty/Chicken/Chile-Chicken-Verde-Casserole.md
@@ -8,13 +8,31 @@ tags:
   - mexican
   - casserole
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 2.75
   greens: 2
+  condiments: 2.75
+  snack: 0
 ---
 # Chile Chicken Verde Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 servings

--- a/docs/hearty/Chicken/Chile-Rellenos.md
+++ b/docs/hearty/Chicken/Chile-Rellenos.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
   - mexican
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1.25
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1.5
+  condiments: 1.25
+  snack: 0
 ---
 # Chile Rellenos
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 4 Serving
 Per Serving: 1 Lean, 1.5 Greens, 1.25 Condiments

--- a/docs/hearty/Chicken/Chinese-Orange-Chicken.md
+++ b/docs/hearty/Chicken/Chinese-Orange-Chicken.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - cauliflower
   - asian
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Chinese Orange Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 9 oz raw chicken breasts, cubed - should yield 6 oz cooked (1 Lean)

--- a/docs/hearty/Chicken/Chipotle-Chicken-with-Avocado-Salsa.md
+++ b/docs/hearty/Chicken/Chipotle-Chicken-with-Avocado-Salsa.md
@@ -8,11 +8,31 @@ tags:
   - zucchini
   - mexican
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Chipotle Chicken with Avocado Salsa
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 Per serving

--- a/docs/hearty/Chicken/Cilantro-Lime-Chicken-with-Avocado-Salsa.md
+++ b/docs/hearty/Chicken/Cilantro-Lime-Chicken-with-Avocado-Salsa.md
@@ -5,11 +5,31 @@ tags:
   - main
   - chicken
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Cilantro Lime Chicken with Avocado Salsa
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving:

--- a/docs/hearty/Chicken/Cowboy-Butter-Chicken-with-Zoodles.md
+++ b/docs/hearty/Chicken/Cowboy-Butter-Chicken-with-Zoodles.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - zucchini
 servings: 5
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Cowboy Butter Chicken with Zoodles
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 5 servings
 

--- a/docs/hearty/Chicken/Creamy-Buffalo-Chicken-Bake-Dip.md
+++ b/docs/hearty/Chicken/Creamy-Buffalo-Chicken-Bake-Dip.md
@@ -8,13 +8,31 @@ tags:
   - american
   - dip
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1.5
   greens: 3
+  condiments: 1.5
+  snack: 0
 ---
 # Creamy Buffalo Chicken Bake Dip
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 Serving

--- a/docs/hearty/Chicken/Creamy-Skillet-Chicken-and-Asparagus-Recipe.md
+++ b/docs/hearty/Chicken/Creamy-Skillet-Chicken-and-Asparagus-Recipe.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - stovetop
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 2
+  condiments: 2
+  snack: 0
 ---
 # Creamy Skillet Chicken and Asparagus Recipe
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 tsp olive oil (4 healthy fats)

--- a/docs/hearty/Chicken/Creamy-Tuscan-Garlic-Chicken.md
+++ b/docs/hearty/Chicken/Creamy-Tuscan-Garlic-Chicken.md
@@ -7,11 +7,31 @@ tags:
   - zucchini
   - italian
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Creamy Tuscan Garlic Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 3 servings
 Per serving

--- a/docs/hearty/Chicken/CreamySwissChickenBake.md
+++ b/docs/hearty/Chicken/CreamySwissChickenBake.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - oven
 servings: 8
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Creamy Swiss Chicken Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 8 servings
 Each serving provides:

--- a/docs/hearty/Chicken/Easy-Chicken-and-Veggie-Salad.md
+++ b/docs/hearty/Chicken/Easy-Chicken-and-Veggie-Salad.md
@@ -5,11 +5,31 @@ tags:
   - main
   - chicken
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 0
+  snack: 0
 ---
 # Easy Chicken and Veggie Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 6 oz cooked chicken breast (1 leaner)

--- a/docs/hearty/Chicken/Enchilada-Bake.md
+++ b/docs/hearty/Chicken/Enchilada-Bake.md
@@ -7,13 +7,31 @@ tags:
   - oven
   - mexican
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 3
-  condiments: 3
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Enchilada Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 3 Servings 
 Each serving provides 

--- a/docs/hearty/Chicken/Filipino-Chicken-Adobo.md
+++ b/docs/hearty/Chicken/Filipino-Chicken-Adobo.md
@@ -7,11 +7,31 @@ tags:
   - cauliflower
   - asian
 servings: 5
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Filipino Chicken Adobo
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 3 pounds skinless, boneless chicken breasts

--- a/docs/hearty/Chicken/Garlic-Butter-Chicken-Bites-with-Lemon-Asparagus.md
+++ b/docs/hearty/Chicken/Garlic-Butter-Chicken-Bites-with-Lemon-Asparagus.md
@@ -5,13 +5,31 @@ tags:
   - main
   - chicken
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Garlic Butter Chicken Bites with Lemon Asparagus
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 36.4 oz boneless, skinless chicken breast, cut into bite-sized chunks (4 leaners)

--- a/docs/hearty/Chicken/Greek-Chicken-Burgers-with-Tzatziki-Sauce.md
+++ b/docs/hearty/Chicken/Greek-Chicken-Burgers-with-Tzatziki-Sauce.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
   - mediterranean
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Greek Chicken Burgers with Tzatziki Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Chicken/Greek-Chicken-Stew.md
+++ b/docs/hearty/Chicken/Greek-Chicken-Stew.md
@@ -7,11 +7,31 @@ tags:
   - cauliflower
   - mediterranean
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Greek Chicken Stew
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Chicken/Greek-Lemon-Chicken-Salad.md
+++ b/docs/hearty/Chicken/Greek-Lemon-Chicken-Salad.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - mediterranean
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 2.5
   greens: 1
+  condiments: 2.5
+  snack: 0
 ---
 # Greek Lemon Chicken Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 Serving

--- a/docs/hearty/Chicken/Greek-Stuffed-Chicken.md
+++ b/docs/hearty/Chicken/Greek-Stuffed-Chicken.md
@@ -8,13 +8,31 @@ tags:
   - mediterranean
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 2.5
   greens: 1.5
+  condiments: 2.5
+  snack: 0
 ---
 # Greek Stuffed Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 

--- a/docs/hearty/Chicken/Green-Chile-Chicken-Enchilada-Stuffed-Spaghetti-Squash.md
+++ b/docs/hearty/Chicken/Green-Chile-Chicken-Enchilada-Stuffed-Spaghetti-Squash.md
@@ -8,12 +8,31 @@ tags:
   - mexican
   - stuffed
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Green Chile Chicken Enchilada Stuffed Spaghetti Squash
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ![Green Chile Chicken Enchilada Stuffed Spaghetti Squash](./Green-Chile-Chicken-Enchilada-Stuffed-Spaghetti-Squash.jpeg)
 

--- a/docs/hearty/Chicken/Grilled-Chicken-Bruschetta.md
+++ b/docs/hearty/Chicken/Grilled-Chicken-Bruschetta.md
@@ -5,13 +5,31 @@ tags:
   - main
   - chicken
   - grill
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Grilled Chicken Bruschetta
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Serving size: 4
 Per Serving: 1 leaner, 1 healthy fat, ½ green and ~3 condiments

--- a/docs/hearty/Chicken/Grilled-Chicken-with-Peanut-Sauce-1.md
+++ b/docs/hearty/Chicken/Grilled-Chicken-with-Peanut-Sauce-1.md
@@ -7,12 +7,31 @@ tags:
   - grill
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 2
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2.5
+  snack: 1
 ---
 # Grilled Chicken with Peanut Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 12 oz chicken tenderloins, grilled (2 Lean)

--- a/docs/hearty/Chicken/Grilled-Chicken-with-Peanut-Sauce.md
+++ b/docs/hearty/Chicken/Grilled-Chicken-with-Peanut-Sauce.md
@@ -7,12 +7,31 @@ tags:
   - grill
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 2
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2.5
+  snack: 1
 ---
 # Grilled Chicken with Peanut Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 2 Servings of Lean | 2.5 Condiments | 1 Snack per Serving
  *A serving is 6 oz of chicken and 1/2 of the sauce)

--- a/docs/hearty/Chicken/Instant-Pot-Chipotle-Chicken-Cauliflower-Rice-Bowls.md
+++ b/docs/hearty/Chicken/Instant-Pot-Chipotle-Chicken-Cauliflower-Rice-Bowls.md
@@ -7,13 +7,31 @@ tags:
   - instant-pot
   - cauliflower
   - mexican
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Instant Pot Chipotle Chicken & Cauliflower Rice Bowls
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 Leaner | 1 Healthy Fat | 3 Green | 3 Condiments
 Yield: 4 servings 

--- a/docs/hearty/Chicken/Italian-Chicken-Bake.md
+++ b/docs/hearty/Chicken/Italian-Chicken-Bake.md
@@ -7,11 +7,31 @@ tags:
   - oven
   - italian
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Italian Chicken Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 

--- a/docs/hearty/Chicken/Jalapeno-Popper-Chicken.md
+++ b/docs/hearty/Chicken/Jalapeno-Popper-Chicken.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 0.33
+  condiments: 3
+  snack: 0
 ---
 # Jalapeno Popper Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 6 Servings, per serving:
 1 Lean

--- a/docs/hearty/Chicken/Jalapeño-Chicken-Bake.md
+++ b/docs/hearty/Chicken/Jalapeño-Chicken-Bake.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - oven
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 0.33
+  condiments: 3
+  snack: 0
 ---
 # Jalapeño Chicken Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving:

--- a/docs/hearty/Chicken/Jalapeño-Popper-Chicken-Dip.md
+++ b/docs/hearty/Chicken/Jalapeño-Popper-Chicken-Dip.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - dip
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 1.75
+  snack: 0
 ---
 # Jalapeño Popper Chicken Dip
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings, per serving you enjoy:
 1 Lean | 1.75 Condiments | 1 Healthy Fat

--- a/docs/hearty/Chicken/Key-West-Chicken.md
+++ b/docs/hearty/Chicken/Key-West-Chicken.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 2
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Key West Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 2 (over 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings, each serving gives 2 leaners (6 ounces cooked chicken each), 3 condiments, and 1 healthy fat.
 

--- a/docs/hearty/Chicken/Kung-Pao-Chicken.md
+++ b/docs/hearty/Chicken/Kung-Pao-Chicken.md
@@ -7,11 +7,31 @@ tags:
   - zucchini
   - asian
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Kung Pao Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Chicken/LasagnaStuffedChicken.md
+++ b/docs/hearty/Chicken/LasagnaStuffedChicken.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 2
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 2
+  snack: 0
 ---
 # Lasagna Stuffed Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 2 – 9.1 ounce raw skinless chicken breast (2 leaners)

--- a/docs/hearty/Chicken/Laughing-cow-stuffed-chicken.md
+++ b/docs/hearty/Chicken/Laughing-cow-stuffed-chicken.md
@@ -7,13 +7,31 @@ tags:
   - cauliflower
   - stuffed
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Laughing cow stuffed chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Chicken/Layered-Enchilada-Bake.md
+++ b/docs/hearty/Chicken/Layered-Enchilada-Bake.md
@@ -7,12 +7,31 @@ tags:
   - oven
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 1
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Layered Enchilada Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 This is layered like a lasagna. Make rectangular spinach "noodles" instead of round "shells".
 

--- a/docs/hearty/Chicken/Lean-Parmesan-Chicken-Strips.md
+++ b/docs/hearty/Chicken/Lean-Parmesan-Chicken-Strips.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - italian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Lean Parmesan Chicken Strips
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Chicken/Lemon-Pepper-Chicken-Kale-Stir-Fry.md
+++ b/docs/hearty/Chicken/Lemon-Pepper-Chicken-Kale-Stir-Fry.md
@@ -7,11 +7,31 @@ tags:
   - stovetop
   - asian
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Lemon Pepper Chicken & Kale Stir Fry
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 3 servings

--- a/docs/hearty/Chicken/Loaded-Cauliflower-and-Buffalo-Chicken-Casserole.md
+++ b/docs/hearty/Chicken/Loaded-Cauliflower-and-Buffalo-Chicken-Casserole.md
@@ -8,13 +8,31 @@ tags:
   - american
   - casserole
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Loaded Cauliflower and Buffalo Chicken Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving: 1 leaner protein, 3 vegetables, 1 healthy fat, 3 condiments

--- a/docs/hearty/Chicken/Melt-in-Your-Mouth-Chicken.md
+++ b/docs/hearty/Chicken/Melt-in-Your-Mouth-Chicken.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2.5
+  snack: 0
 ---
 # Melt in Your Mouth Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 servings

--- a/docs/hearty/Chicken/Mexican-Chicken.md
+++ b/docs/hearty/Chicken/Mexican-Chicken.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - mexican
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 1
+  snack: 0
 ---
 # Mexican Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 makes 3 servings
 per serving:

--- a/docs/hearty/Chicken/Monterey-Chicken.md
+++ b/docs/hearty/Chicken/Monterey-Chicken.md
@@ -5,11 +5,31 @@ tags:
   - main
   - chicken
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Monterey Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 3 servings
 Each serving provides:

--- a/docs/hearty/Chicken/One-Pot-Chicken-Mushroom-Cauliflower-Rice.md
+++ b/docs/hearty/Chicken/One-Pot-Chicken-Mushroom-Cauliflower-Rice.md
@@ -6,11 +6,31 @@ tags:
   - chicken
   - cauliflower
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # One-Pot Chicken & Mushroom Cauliflower Rice
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 3 servings

--- a/docs/hearty/Chicken/Oven-Roasted-Chicken-Shawarma.md
+++ b/docs/hearty/Chicken/Oven-Roasted-Chicken-Shawarma.md
@@ -7,12 +7,31 @@ tags:
   - oven
   - asian
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Oven-Roasted Chicken Shawarma
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Each serving provides:

--- a/docs/hearty/Chicken/PESTO-CHICKEN-WITH-ZUCCHINI-NOODLES.md
+++ b/docs/hearty/Chicken/PESTO-CHICKEN-WITH-ZUCCHINI-NOODLES.md
@@ -7,13 +7,31 @@ tags:
   - zucchini
   - italian
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # PESTO CHICKEN WITH ZUCCHINI NOODLES
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings and per serving you receive:
 1 leaner protein

--- a/docs/hearty/Chicken/Peanut-Chicken.md
+++ b/docs/hearty/Chicken/Peanut-Chicken.md
@@ -5,11 +5,31 @@ tags:
   - main
   - chicken
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2.5
+  snack: 1
 ---
 # Peanut Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 

--- a/docs/hearty/Chicken/Perfect-Roast-Chicken-with-Lemon-and-Rosemary.md
+++ b/docs/hearty/Chicken/Perfect-Roast-Chicken-with-Lemon-and-Rosemary.md
@@ -6,11 +6,31 @@ tags:
   - chicken
   - oven
 servings: 5
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Perfect Roast Chicken with Lemon and Rosemary
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 5 servings
 Per serving

--- a/docs/hearty/Chicken/Pesto-Chicken-Bruschetta.md
+++ b/docs/hearty/Chicken/Pesto-Chicken-Bruschetta.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - italian
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Pesto Chicken Bruschetta
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 (6 oz) boneless, skinless chicken breasts

--- a/docs/hearty/Chicken/Poblano-Chicken-Casserole.md
+++ b/docs/hearty/Chicken/Poblano-Chicken-Casserole.md
@@ -7,12 +7,31 @@ tags:
   - mexican
   - casserole
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
   greens: 3
+  condiments: 0
+  snack: 0
 ---
 # Poblano Chicken Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 # Poblano Chicken Casserole
 4 servings; Per serving

--- a/docs/hearty/Chicken/Pressure-Cooker-Lemon-Olive-Chicken.md
+++ b/docs/hearty/Chicken/Pressure-Cooker-Lemon-Olive-Chicken.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
   - pressure-cooker
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Pressure Cooker Lemon Olive Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 4 servings
 Per serving: 1 leaner | 1 healthy fat | 3 condiments

--- a/docs/hearty/Chicken/Rotisserie-Style-Chicken-in-the-Slow-Cooker.md
+++ b/docs/hearty/Chicken/Rotisserie-Style-Chicken-in-the-Slow-Cooker.md
@@ -6,11 +6,31 @@ tags:
   - chicken
   - slow-cooker
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2.3
+  snack: 0
 ---
 # Rotisserie Style Chicken in the Slow Cooker
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 4 Servings with 1 Lean and 2.3 Condiments per serving
 

--- a/docs/hearty/Chicken/Skillet-Cheesy-Chicken-And-Veggie-Rice.md
+++ b/docs/hearty/Chicken/Skillet-Cheesy-Chicken-And-Veggie-Rice.md
@@ -7,13 +7,31 @@ tags:
   - stovetop
   - cauliflower
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 2
-  condiments: 2
   greens: 2
+  condiments: 2
+  snack: 0
 ---
 # Skillet Cheesy Chicken And Veggie “Rice”
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 

--- a/docs/hearty/Chicken/Slow-Cooker-Cashew-Chicken.md
+++ b/docs/hearty/Chicken/Slow-Cooker-Cashew-Chicken.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - slow-cooker
   - asian
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Slow Cooker Cashew Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 1/2 lbs or 24 oz raw chicken breasts, cut into 1 inch pieces (3 Leaner)

--- a/docs/hearty/Chicken/Sour-Cream-Chicken-Enchilada-Skillet.md
+++ b/docs/hearty/Chicken/Sour-Cream-Chicken-Enchilada-Skillet.md
@@ -7,12 +7,31 @@ tags:
   - stovetop
   - mexican
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Sour Cream Chicken Enchilada Skillet
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving

--- a/docs/hearty/Chicken/Spicy-Chicken-Tagine.md
+++ b/docs/hearty/Chicken/Spicy-Chicken-Tagine.md
@@ -6,11 +6,31 @@ tags:
   - chicken
   - zucchini
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Spicy Chicken Tagine
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 

--- a/docs/hearty/Chicken/Spinach-Mushroom-Chicken.md
+++ b/docs/hearty/Chicken/Spinach-Mushroom-Chicken.md
@@ -5,13 +5,31 @@ tags:
   - main
   - chicken
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 6
-  condiments: 0.67
   greens: 4
+  condiments: 0.67
+  snack: 0
 ---
 # Spinach Mushroom Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">6</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.67</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving

--- a/docs/hearty/Chicken/Stuffed-Chicken-Parmesan-Meatloaf.md
+++ b/docs/hearty/Chicken/Stuffed-Chicken-Parmesan-Meatloaf.md
@@ -9,11 +9,31 @@ tags:
   - stuffed
   - meatballs
 servings: 8
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Stuffed Chicken Parmesan Meatloaf
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: Makes 8 Servings
 

--- a/docs/hearty/Chicken/Sun-dried-Tomato-Spinach-and-Cheese-Stuffed-Chicken-Breast.md
+++ b/docs/hearty/Chicken/Sun-dried-Tomato-Spinach-and-Cheese-Stuffed-Chicken-Breast.md
@@ -6,13 +6,31 @@ tags:
   - chicken
   - stuffed
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 2
-  condiments: 3
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Sun-dried Tomato, Spinach, and Cheese Stuffed Chicken Breast
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 18 ounces chicken breasts, boneless and skinless (2 Leaner)

--- a/docs/hearty/Chicken/Sweet-Chili-Coconut-Lime-Grilled-Chicken-with-Coconut-Lime-Cauliflower….md
+++ b/docs/hearty/Chicken/Sweet-Chili-Coconut-Lime-Grilled-Chicken-with-Coconut-Lime-Cauliflower….md
@@ -7,13 +7,31 @@ tags:
   - grill
   - cauliflower
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 12
+  condiments: 3
+  snack: 0
 ---
 # Sweet Chili Coconut-Lime Grilled Chicken with Coconut-Lime Cauliflower Rice
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">12</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 3/4 cup unsweetened light coconut milk, divided (3 healthy fats)

--- a/docs/hearty/Chicken/Taste-of-Thai-Crock-Pot-Chicken.md
+++ b/docs/hearty/Chicken/Taste-of-Thai-Crock-Pot-Chicken.md
@@ -7,10 +7,31 @@ tags:
   - slow-cooker
   - cauliflower
   - asian
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0.25
 ---
 # Taste of Thai Crock Pot Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Per Serving:
 4 Complete Lean and Green Meals with 3 Condiments and 1/4 Snack per Serving

--- a/docs/hearty/Chicken/Tex-Mex-Chopped-Chicken-Salad-Recipe.md
+++ b/docs/hearty/Chicken/Tex-Mex-Chopped-Chicken-Salad-Recipe.md
@@ -5,12 +5,31 @@ tags:
   - main
   - chicken
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Tex-Mex Chopped Chicken Salad Recipe
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings:
 · 1 leaner protein

--- a/docs/hearty/Chicken/Tex-Mex-Chopped-Chicken-Salad.md
+++ b/docs/hearty/Chicken/Tex-Mex-Chopped-Chicken-Salad.md
@@ -5,13 +5,32 @@ tags:
   - main
   - chicken
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Tex-Mex Chopped Chicken Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 ⁪
 Makes 4 servings
 Each serving provides: 1 leaner protein, 1 healthy fat, 2 greens, 3 condiments

--- a/docs/hearty/Chicken/Thai-Chicken-Zucchini-Noodles-with-Spicy-Peanut-Sauce.md
+++ b/docs/hearty/Chicken/Thai-Chicken-Zucchini-Noodles-with-Spicy-Peanut-Sauce.md
@@ -6,11 +6,31 @@ tags:
   - chicken
   - zucchini
   - asian
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Thai Chicken Zucchini Noodles with Spicy Peanut Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Serves: 4
 Per serving:

--- a/docs/hearty/Chicken/Thai-Peanut-Chicken-Pizza.md
+++ b/docs/hearty/Chicken/Thai-Peanut-Chicken-Pizza.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - asian
   - pizza
-fueling:
+LeanAndGreen:
   lean: 0.25
-  condiments: 2.5
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 0.25
+  condiments: 2.5
+  snack: 1
 ---
 # Thai Peanut Chicken Pizza
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Chicken/Tofu-or-chicken-and-Broccoli-Stir-Fry-with-Peanut-Sauce.md
+++ b/docs/hearty/Chicken/Tofu-or-chicken-and-Broccoli-Stir-Fry-with-Peanut-Sauce.md
@@ -8,11 +8,31 @@ tags:
   - tofu
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2.5
+  snack: 75
 ---
 # Tofu {or chicken} and Broccoli Stir Fry with Peanut Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 servings

--- a/docs/hearty/Chicken/Zucchini-Chicken-Enchiladas.md
+++ b/docs/hearty/Chicken/Zucchini-Chicken-Enchiladas.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - zucchini
 servings: 5
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Zucchini Chicken Enchiladas
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 5 servings
 

--- a/docs/hearty/Chicken/Zucchini-Noodles-with-Cilantro-Lime-Chicken.md
+++ b/docs/hearty/Chicken/Zucchini-Noodles-with-Cilantro-Lime-Chicken.md
@@ -6,12 +6,31 @@ tags:
   - chicken
   - zucchini
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
-  condiments: 3
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Zucchini Noodles with Cilantro Lime Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 3 servings and per serving you receive:
 1 leaner protein

--- a/docs/hearty/Pork/Mexican-Style-Shredded-Pork.md
+++ b/docs/hearty/Pork/Mexican-Style-Shredded-Pork.md
@@ -7,12 +7,31 @@ tags:
   - slow-cooker
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 4
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 2
+  snack: 0
 ---
 # Mexican Style Shredded Pork
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 4 (over 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 4 (over 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 4 (over 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 2 lb pork loin roast (4 Leans)

--- a/docs/hearty/Pork/Zesty-Pork-Stir-Fry.md
+++ b/docs/hearty/Pork/Zesty-Pork-Stir-Fry.md
@@ -7,11 +7,31 @@ tags:
   - stovetop
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Zesty Pork Stir-Fry
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings, each serving is 
 1 lean protein

--- a/docs/hearty/Seafood/BBQ-Ranch-Shrimp-Salad.md
+++ b/docs/hearty/Seafood/BBQ-Ranch-Shrimp-Salad.md
@@ -7,13 +7,31 @@ tags:
   - shrimp
   - american
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # BBQ Ranch Shrimp Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 9 oz raw shrimp ~ should yield 7 oz cooked (1 Leanest)

--- a/docs/hearty/Seafood/Bang-Bang-Shrimp.md
+++ b/docs/hearty/Seafood/Bang-Bang-Shrimp.md
@@ -6,13 +6,31 @@ tags:
   - seafood
   - air-fryer
   - shrimp
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 1
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Bang Bang Shrimp
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 7 oz of cooked shrimp in the air fryer for 3 mins (1 leanest)

--- a/docs/hearty/Seafood/Blackened-Salmon-Cauliflower-Asparagus-soup.md
+++ b/docs/hearty/Seafood/Blackened-Salmon-Cauliflower-Asparagus-soup.md
@@ -8,12 +8,31 @@ tags:
   - salmon
   - cauliflower
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 1
+  snack: 0
 ---
 # Blackened Salmon Cauliflower Asparagus soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 serving lean and green
 

--- a/docs/hearty/Seafood/Cajun-Shrimp-Turkey-Sausage-and-Vegetable-Skillet.md
+++ b/docs/hearty/Seafood/Cajun-Shrimp-Turkey-Sausage-and-Vegetable-Skillet.md
@@ -9,13 +9,31 @@ tags:
   - zucchini
   - cajun
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 1
-  condiments: 2.33
   greens: 3
+  condiments: 2.33
+  snack: 0
 ---
 # Cajun Shrimp, Turkey Sausage, and Vegetable Skillet
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 6 servings

--- a/docs/hearty/Seafood/Cajun-Shrimp.md
+++ b/docs/hearty/Seafood/Cajun-Shrimp.md
@@ -7,12 +7,31 @@ tags:
   - shrimp
   - cajun
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 1.75
+  snack: 0
 ---
 # Cajun Shrimp
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 Serving
 

--- a/docs/hearty/Seafood/Cajun-Style-Shrimp-Skillet.md
+++ b/docs/hearty/Seafood/Cajun-Style-Shrimp-Skillet.md
@@ -9,13 +9,31 @@ tags:
   - cauliflower
   - cajun
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cajun Style Shrimp Skillet
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 tbsp light butter (1 Healthy Fat)

--- a/docs/hearty/Seafood/Caribbean-Fish.md
+++ b/docs/hearty/Seafood/Caribbean-Fish.md
@@ -5,12 +5,31 @@ tags:
   - main
   - seafood
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
-  condiments: 3
+  healthy_fats: 0
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Caribbean Fish
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 Servings

--- a/docs/hearty/Seafood/Cheesy-Tuna-and-Noodles.md
+++ b/docs/hearty/Seafood/Cheesy-Tuna-and-Noodles.md
@@ -7,12 +7,31 @@ tags:
   - tuna
   - zucchini
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Cheesy Tuna and Noodles
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 servings

--- a/docs/hearty/Seafood/Chimichurri-Shrimp.md
+++ b/docs/hearty/Seafood/Chimichurri-Shrimp.md
@@ -7,12 +7,31 @@ tags:
   - shrimp
   - zucchini
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Chimichurri Shrimp
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 

--- a/docs/hearty/Seafood/Cilantro-Lime-Shrimp-Wraps.md
+++ b/docs/hearty/Seafood/Cilantro-Lime-Shrimp-Wraps.md
@@ -7,13 +7,31 @@ tags:
   - shrimp
   - wraps
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Cilantro-Lime Shrimp Wraps
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 33.6 oz medium shrimp, peeled and deveined (3 leanest)

--- a/docs/hearty/Seafood/Cod-with-Squash.md
+++ b/docs/hearty/Seafood/Cod-with-Squash.md
@@ -6,13 +6,31 @@ tags:
   - seafood
   - cod
   - zucchini
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Cod with Squash
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 (4 servings: 1 leanest, 2 healthy fats, 3 green, and 1 condiment per serving)
 

--- a/docs/hearty/Seafood/Crab-Cakes.md
+++ b/docs/hearty/Seafood/Crab-Cakes.md
@@ -6,12 +6,31 @@ tags:
   - seafood
   - crab
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Crab Cakes
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 14 oz crabmeat

--- a/docs/hearty/Seafood/Crab-Stuffed-Cucumbers.md
+++ b/docs/hearty/Seafood/Crab-Stuffed-Cucumbers.md
@@ -6,12 +6,31 @@ tags:
   - seafood
   - crab
   - stuffed
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Crab-Stuffed Cucumbers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Serves 4
 Per serving 3 green, 1 healthy fat, 1 condiment, and ½ leanest

--- a/docs/hearty/Seafood/Crab-stuffed-Mushrooms.md
+++ b/docs/hearty/Seafood/Crab-stuffed-Mushrooms.md
@@ -7,12 +7,31 @@ tags:
   - crab
   - stuffed
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 0.5
-  condiments: 3
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Crab-stuffed Mushrooms
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Seafood/Creamy-Zucchini-Pasta-Jambalaya.md
+++ b/docs/hearty/Seafood/Creamy-Zucchini-Pasta-Jambalaya.md
@@ -8,13 +8,31 @@ tags:
   - zucchini
   - cajun
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1.5
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Creamy Zucchini Pasta Jambalaya
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Seafood/Dijon-Salmon-Cakes-and-Arugula-with-Lemon-Caper-Oil.md
+++ b/docs/hearty/Seafood/Dijon-Salmon-Cakes-and-Arugula-with-Lemon-Caper-Oil.md
@@ -6,11 +6,31 @@ tags:
   - seafood
   - salmon
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Dijon Salmon Cakes and Arugula with Lemon-Caper Oil
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 servings

--- a/docs/hearty/Seafood/Firecracker-Grilled-Salmon.md
+++ b/docs/hearty/Seafood/Firecracker-Grilled-Salmon.md
@@ -7,12 +7,31 @@ tags:
   - grill
   - salmon
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Firecracker Grilled Salmon
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 tablespoon balsamic vinegar (3 condiments)

--- a/docs/hearty/Seafood/Grilled-Buffalo-Shrimp.md
+++ b/docs/hearty/Seafood/Grilled-Buffalo-Shrimp.md
@@ -8,12 +8,31 @@ tags:
   - shrimp
   - american
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Grilled Buffalo Shrimp
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Seafood/Grilled-Lemon-Ginger-Shrimp.md
+++ b/docs/hearty/Seafood/Grilled-Lemon-Ginger-Shrimp.md
@@ -6,12 +6,31 @@ tags:
   - seafood
   - grill
   - shrimp
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Grilled Lemon Ginger Shrimp
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 20 ounces jumbo shrimp, peeled and deveined when cooked - should yield 2 - 7 oz servings cooked (2 Leans)

--- a/docs/hearty/Seafood/Indian-Shrimp-Curry.md
+++ b/docs/hearty/Seafood/Indian-Shrimp-Curry.md
@@ -7,11 +7,31 @@ tags:
   - shrimp
   - cauliflower
 servings: 4
-fueling:
-  condiments: 3
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Indian Shrimp Curry
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Seafood/Jicama-Tuna-Salad-Stuffed-Peppers.md
+++ b/docs/hearty/Seafood/Jicama-Tuna-Salad-Stuffed-Peppers.md
@@ -7,13 +7,31 @@ tags:
   - tuna
   - stuffed
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Jicama Tuna Salad Stuffed Peppers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4.6 oz canned tuna, drained (2/3 Lean)*

--- a/docs/hearty/Seafood/Light-Tuna-Casserole.md
+++ b/docs/hearty/Seafood/Light-Tuna-Casserole.md
@@ -8,13 +8,31 @@ tags:
   - spaghetti-squash
   - casserole
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1.5
   greens: 2
+  condiments: 1.5
+  snack: 0
 ---
 # Light Tuna Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 Servings

--- a/docs/hearty/Seafood/Quick-and-Easy-Mock-Shrimp-Risotto.md
+++ b/docs/hearty/Seafood/Quick-and-Easy-Mock-Shrimp-Risotto.md
@@ -7,13 +7,31 @@ tags:
   - shrimp
   - cauliflower
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Quick and Easy Mock Shrimp "Risotto"
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/hearty/Seafood/Roasted-Shrimp-And-Veggie-Salad.md
+++ b/docs/hearty/Seafood/Roasted-Shrimp-And-Veggie-Salad.md
@@ -7,10 +7,31 @@ tags:
   - oven
   - shrimp
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Roasted Shrimp And Veggie Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Seafood/Seared-Scallops-with-Cauliflower-Puree.md
+++ b/docs/hearty/Seafood/Seared-Scallops-with-Cauliflower-Puree.md
@@ -7,11 +7,31 @@ tags:
   - scallops
   - cauliflower
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
+  greens: 0
   condiments: 0.5
+  snack: 0
 ---
 # Seared Scallops with Cauliflower Puree
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 # Seared Scallops with Cauliflower Puree
 

--- a/docs/hearty/Seafood/Seared-Scallops-with-Coconut-Curry-Sauce.md
+++ b/docs/hearty/Seafood/Seared-Scallops-with-Coconut-Curry-Sauce.md
@@ -7,12 +7,32 @@ tags:
   - scallops
   - cauliflower
   - asian
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Seared Scallops with Coconut Curry Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 Slightly adapted from Robin Seidel
 
 ## Ingredients

--- a/docs/hearty/Seafood/Shrimp-Avocado-Cauliflower-Rice-Sushi.md
+++ b/docs/hearty/Seafood/Shrimp-Avocado-Cauliflower-Rice-Sushi.md
@@ -8,13 +8,31 @@ tags:
   - cauliflower
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Shrimp & Avocado Cauliflower Rice Sushi
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 Servings (2 rolls per serving)

--- a/docs/hearty/Seafood/Shrimp-Salad-with-Peanut-Dressing.md
+++ b/docs/hearty/Seafood/Shrimp-Salad-with-Peanut-Dressing.md
@@ -6,13 +6,31 @@ tags:
   - seafood
   - shrimp
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 1
 ---
 # Shrimp Salad with Peanut Dressing
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 1/2 cups tri-color coleslaw mix OR 1 1/2 cup shredded cabbage (3 Greens) (adjust if you want to add tomatoes)

--- a/docs/hearty/Seafood/Shrimp-and-sausage-kabobs.md
+++ b/docs/hearty/Seafood/Shrimp-and-sausage-kabobs.md
@@ -6,13 +6,31 @@ tags:
   - seafood
   - shrimp
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 1
 ---
 # Shrimp and sausage kabobs
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 serving
 

--- a/docs/hearty/Seafood/Spaghetti-Squash-Pad-Thai.md
+++ b/docs/hearty/Seafood/Spaghetti-Squash-Pad-Thai.md
@@ -8,12 +8,31 @@ tags:
   - spaghetti-squash
   - asian
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2
+  snack: 1
 ---
 # Spaghetti Squash Pad Thai
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 3 1/2 cups spaghetti squash, cooked (7 Greens)

--- a/docs/hearty/Seafood/Spaghetti-Squash-with-Shrimp-and-Turkey-Bacon-1.md
+++ b/docs/hearty/Seafood/Spaghetti-Squash-with-Shrimp-and-Turkey-Bacon-1.md
@@ -7,13 +7,31 @@ tags:
   - shrimp
   - spaghetti-squash
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Spaghetti Squash with Shrimp and Turkey Bacon
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 tsp olive oil (1 Healthy Fat)

--- a/docs/hearty/Seafood/Spaghetti-Squash-with-Shrimp-and-Turkey-Bacon-2.md
+++ b/docs/hearty/Seafood/Spaghetti-Squash-with-Shrimp-and-Turkey-Bacon-2.md
@@ -7,13 +7,31 @@ tags:
   - shrimp
   - spaghetti-squash
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Spaghetti Squash with Shrimp and Turkey Bacon
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Seafood/Spaghetti-Squash-with-Shrimp-and-Turkey-Bacon.md
+++ b/docs/hearty/Seafood/Spaghetti-Squash-with-Shrimp-and-Turkey-Bacon.md
@@ -7,13 +7,31 @@ tags:
   - shrimp
   - spaghetti-squash
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Spaghetti Squash with Shrimp and Turkey Bacon
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Seafood/Summer-Shrimp-Salad.md
+++ b/docs/hearty/Seafood/Summer-Shrimp-Salad.md
@@ -5,13 +5,31 @@ tags:
   - main
   - seafood
   - shrimp
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Summer Shrimp Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 14 ounces jumbo cooked shrimp, peeled, deveined and chopped

--- a/docs/hearty/Seafood/Surf-Turf-in-Creamy-Cajun-Sauce.md
+++ b/docs/hearty/Seafood/Surf-Turf-in-Creamy-Cajun-Sauce.md
@@ -7,12 +7,31 @@ tags:
   - shrimp
   - cauliflower
   - cajun
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Surf & Turf in Creamy Cajun Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients 
 - [ ] 1 tsp olive oil

--- a/docs/hearty/Seafood/Teriyaki-Salmon-Bites.md
+++ b/docs/hearty/Seafood/Teriyaki-Salmon-Bites.md
@@ -7,12 +7,31 @@ tags:
   - salmon
   - asian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2.75
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 0.12
+  condiments: 2.75
+  snack: 0
 ---
 # Teriyaki Salmon Bites
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.12</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 
 

--- a/docs/hearty/Seafood/Teriyaki-Tuna-Kabobs.md
+++ b/docs/hearty/Seafood/Teriyaki-Tuna-Kabobs.md
@@ -7,13 +7,31 @@ tags:
   - tuna
   - asian
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 4
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Teriyaki Tuna Kabobs
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 Ahi tuna steaks (10 ounces each), cut into 1-1/2-in. chunks (4 leanest)

--- a/docs/hearty/Seafood/Tomato-Shrimp-Salad.md
+++ b/docs/hearty/Seafood/Tomato-Shrimp-Salad.md
@@ -5,8 +5,31 @@ tags:
   - main
   - seafood
   - shrimp
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Tomato Shrimp Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 complete Lean & Green
 

--- a/docs/hearty/Seafood/Tuna-wrap.md
+++ b/docs/hearty/Seafood/Tuna-wrap.md
@@ -6,12 +6,31 @@ tags:
   - seafood
   - tuna
   - wraps
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 1
   greens: 1
+  condiments: 0
+  snack: 0
 ---
 # Tuna wrap
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 leanest, 1 green and 1 healthy fat.
 *need 2 additional greens*

--- a/docs/hearty/Seafood/Vietnamese-Spring-Rolls.md
+++ b/docs/hearty/Seafood/Vietnamese-Spring-Rolls.md
@@ -6,13 +6,31 @@ tags:
   - seafood
   - shrimp
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Vietnamese Spring Rolls
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Nutrition:
 400 calories | 15g fat | 11g carbohydrates | 56g protein

--- a/docs/hearty/Turkey/Cauliflower-Crust-Pepperoni-Pizza.md
+++ b/docs/hearty/Turkey/Cauliflower-Crust-Pepperoni-Pizza.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - pizza
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cauliflower Crust Pepperoni Pizza
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Yields
 

--- a/docs/hearty/Turkey/Crock-Pot-Cauliflower-Pizza-Casserole.md
+++ b/docs/hearty/Turkey/Crock-Pot-Cauliflower-Pizza-Casserole.md
@@ -9,10 +9,31 @@ tags:
   - casserole
   - pizza
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 0
+  snack: 0
 ---
 # Crock Pot Cauliflower Pizza Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings 
 Each serving provides: 

--- a/docs/hearty/Turkey/Egg-McMuffin.md
+++ b/docs/hearty/Turkey/Egg-McMuffin.md
@@ -5,11 +5,31 @@ tags:
   - main
   - turkey
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2
+  snack: 0
 ---
 # Egg McMuffin
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 serving

--- a/docs/hearty/Turkey/Italian-Sausage-Sweet-Red-Pepper-Quiche.md
+++ b/docs/hearty/Turkey/Italian-Sausage-Sweet-Red-Pepper-Quiche.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - italian
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1.5
+  condiments: 1
+  snack: 0
 ---
 # Italian Sausage Sweet Red Pepper Quiche
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 6 ounces cooked Jennie-O Sweet Italian turkey sausage links (1 Lean)

--- a/docs/hearty/Turkey/Jalapeno-Cheddar-Turkey-Burgers.md
+++ b/docs/hearty/Turkey/Jalapeno-Cheddar-Turkey-Burgers.md
@@ -5,11 +5,31 @@ tags:
   - main
   - turkey
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 1.33
+  snack: 0
 ---
 # Jalapeno Cheddar Turkey Burgers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 Serving

--- a/docs/hearty/Turkey/Meatball-Lasagna.md
+++ b/docs/hearty/Turkey/Meatball-Lasagna.md
@@ -6,12 +6,31 @@ tags:
   - turkey
   - zucchini
   - meatballs
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Meatball Lasagna
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Per recipe:
 

--- a/docs/hearty/Turkey/My-Big-Greek-Turkey-Burger.md
+++ b/docs/hearty/Turkey/My-Big-Greek-Turkey-Burger.md
@@ -6,12 +6,31 @@ tags:
   - turkey
   - mediterranean
   - burgers
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # My Big Greek Turkey Burger
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Per serving:
 1 Lean

--- a/docs/hearty/Turkey/Oodles-of-Zucchini-Noodles-and-Turkey-Sausage.md
+++ b/docs/hearty/Turkey/Oodles-of-Zucchini-Noodles-and-Turkey-Sausage.md
@@ -6,11 +6,31 @@ tags:
   - turkey
   - zucchini
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 1
+  snack: 0
 ---
 # Oodles of Zucchini Noodles and Turkey Sausage
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 3 Servings

--- a/docs/hearty/Turkey/Pesto-Mozzarella-Stuffed-Meatloaf.md
+++ b/docs/hearty/Turkey/Pesto-Mozzarella-Stuffed-Meatloaf.md
@@ -7,13 +7,31 @@ tags:
   - italian
   - stuffed
   - meatballs
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 1.33
+  condiments: 1
+  snack: 0
 ---
 # Pesto & Mozzarella Stuffed Meatloaf
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Servings 6 servings
 1 lean, 1 1/3 greens, 1 condiment, & 1 healthy fat

--- a/docs/hearty/Turkey/PizzaCasserole.md
+++ b/docs/hearty/Turkey/PizzaCasserole.md
@@ -7,12 +7,31 @@ tags:
   - casserole
   - pizza
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 4.5
+  condiments: 1
+  snack: 0
 ---
 # Pizza Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">4.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 5 servings
 Per serving

--- a/docs/hearty/Turkey/Pot-Sticker-Burgers.md
+++ b/docs/hearty/Turkey/Pot-Sticker-Burgers.md
@@ -5,12 +5,31 @@ tags:
   - main
   - turkey
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
-  condiments: 3
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Pot Sticker Burgers
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 servings

--- a/docs/hearty/Turkey/Provolone-Cloud-Eggs-with-Turkey-Bacon-and-Spinach.md
+++ b/docs/hearty/Turkey/Provolone-Cloud-Eggs-with-Turkey-Bacon-and-Spinach.md
@@ -4,12 +4,31 @@ description: "Provolone Cloud Eggs with Turkey Bacon and Spinach - Lean & Green 
 tags:
   - main
   - turkey
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Provolone Cloud Eggs with Turkey Bacon and Spinach
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients 
 - [ ] 8 eggs at room temperature

--- a/docs/hearty/Turkey/Spaghetti-Squash-Carbonara.md
+++ b/docs/hearty/Turkey/Spaghetti-Squash-Carbonara.md
@@ -7,10 +7,31 @@ tags:
   - spaghetti-squash
   - italian
 servings: 8
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Spaghetti Squash Carbonara
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 2 tsp salt

--- a/docs/hearty/Turkey/Spaghetti-Squash-Lasagna-Casserole.md
+++ b/docs/hearty/Turkey/Spaghetti-Squash-Lasagna-Casserole.md
@@ -7,13 +7,31 @@ tags:
   - spaghetti-squash
   - casserole
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.5
-  condiments: 1
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Spaghetti Squash Lasagna Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 14.24 oz Spaghetti Squash (8 Greens)

--- a/docs/hearty/Turkey/Spaghetti-Squash-Pie.md
+++ b/docs/hearty/Turkey/Spaghetti-Squash-Pie.md
@@ -6,10 +6,31 @@ tags:
   - turkey
   - spaghetti-squash
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Spaghetti Squash Pie
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 12 ounces cooked spaghetti squash 

--- a/docs/hearty/Turkey/Taco-Bake.md
+++ b/docs/hearty/Turkey/Taco-Bake.md
@@ -8,12 +8,31 @@ tags:
   - cauliflower
   - mexican
 servings: 8
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Taco Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Turkey/Turkey-Spaghetti-Squash-Bake.md
+++ b/docs/hearty/Turkey/Turkey-Spaghetti-Squash-Bake.md
@@ -7,8 +7,31 @@ tags:
   - oven
   - spaghetti-squash
 servings: 2
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Turkey Spaghetti Squash Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 servings

--- a/docs/hearty/Turkey/TurkeyTetrazzini.md
+++ b/docs/hearty/Turkey/TurkeyTetrazzini.md
@@ -7,13 +7,31 @@ tags:
   - spaghetti-squash
   - italian
 servings: 8
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 0.5
+  leanest: 0
   healthy_fats: 0.25
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Turkey Tetrazzini
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 0.5 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Yields
 

--- a/docs/hearty/Turkey/Zucchini-Noodles-and-Turkey-Sausage.md
+++ b/docs/hearty/Turkey/Zucchini-Noodles-and-Turkey-Sausage.md
@@ -6,12 +6,31 @@ tags:
   - turkey
   - zucchini
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1.33
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1.33
+  snack: 0
 ---
 # Zucchini Noodles and Turkey Sausage!!
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 3 servings
 Per serving

--- a/docs/hearty/Vegetarian/Baked-Cinnamon-Jicama-Apples.md
+++ b/docs/hearty/Vegetarian/Baked-Cinnamon-Jicama-Apples.md
@@ -5,13 +5,31 @@ tags:
   - main
   - vegetarian
   - oven
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1.8
   greens: 2
+  condiments: 1.8
+  snack: 0
 ---
 # Baked Cinnamon Jicama (Apples) 
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.8</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 3 (1 cup) servings

--- a/docs/hearty/Vegetarian/Baked-Kabocha-or-Crustless-Pumpkin-Pie.md
+++ b/docs/hearty/Vegetarian/Baked-Kabocha-or-Crustless-Pumpkin-Pie.md
@@ -5,11 +5,31 @@ tags:
   - main
   - vegetarian
   - oven
-fueling:
-  condiments: 1
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 4
+  condiments: 1
+  snack: 4
 ---
 # Baked Kabocha or Crustless "Pumpkin" Pie
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/hearty/Vegetarian/BakedCheeseAndTomatoes.md
+++ b/docs/hearty/Vegetarian/BakedCheeseAndTomatoes.md
@@ -6,12 +6,31 @@ tags:
   - vegetarian
   - oven
   - spaghetti-squash
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 0.25
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 0.25
+  snack: 0
 ---
 # Baked Cheese and Tomatoes
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Yields
 Serves one. 1 lean, 3 greens, 1 ¾ condiments (no healthy fats needed)

--- a/docs/hearty/Vegetarian/Basil-feta-and-tomato-Spaghetti-squash.md
+++ b/docs/hearty/Vegetarian/Basil-feta-and-tomato-Spaghetti-squash.md
@@ -8,13 +8,31 @@ tags:
   - spaghetti-squash
   - mediterranean
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 0.25
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 1
   greens: 1
+  condiments: 1
+  snack: 0
 ---
 # Basil, feta, and tomato Spaghetti squash
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 3 cups prepared spaghetti squash (6 greens)

--- a/docs/hearty/Vegetarian/Best-Eggplant-Rollatini-with-Spinach.md
+++ b/docs/hearty/Vegetarian/Best-Eggplant-Rollatini-with-Spinach.md
@@ -5,12 +5,31 @@ tags:
   - main
   - vegetarian
   - eggplant
-fueling:
+LeanAndGreen:
   lean: 0.5
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 2
+  snack: 0
 ---
 # Best Eggplant Rollatini with Spinach
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Serves: 5. Each serving provides ~1/2 lean protein, ~2 greens, and ~2 condiments.
 

--- a/docs/hearty/Vegetarian/Broccoli-Cheese-Casserole.md
+++ b/docs/hearty/Vegetarian/Broccoli-Cheese-Casserole.md
@@ -6,12 +6,31 @@ tags:
   - vegetarian
   - casserole
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.5
+  greens: 0
   condiments: 2.5
+  snack: 0
 ---
 # Broccoli Cheese Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 Serving
 

--- a/docs/hearty/Vegetarian/Caramelized-Onion-Spaghetti-Squash-Casserole.md
+++ b/docs/hearty/Vegetarian/Caramelized-Onion-Spaghetti-Squash-Casserole.md
@@ -7,10 +7,31 @@ tags:
   - spaghetti-squash
   - casserole
 servings: 5
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 1
+  snack: 0
 ---
 # Caramelized Onion Spaghetti Squash Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 5 servings

--- a/docs/hearty/Vegetarian/Cauliflower-Crust-Calzone.md
+++ b/docs/hearty/Vegetarian/Cauliflower-Crust-Calzone.md
@@ -6,10 +6,31 @@ tags:
   - vegetarian
   - cauliflower
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Cauliflower Crust Calzone
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 3 servings

--- a/docs/hearty/Vegetarian/Cauliflower-Crust-Grilled-Cheese.md
+++ b/docs/hearty/Vegetarian/Cauliflower-Crust-Grilled-Cheese.md
@@ -7,10 +7,31 @@ tags:
   - grill
   - cauliflower
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2.25
+  snack: 0
 ---
 # Cauliflower Crust Grilled Cheese
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Vegetarian/Cheesy-Cauliflower-Au-Gratin.md
+++ b/docs/hearty/Vegetarian/Cheesy-Cauliflower-Au-Gratin.md
@@ -6,11 +6,31 @@ tags:
   - vegetarian
   - cauliflower
 servings: 8
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
+  greens: 0
   condiments: 1
+  snack: 0
 ---
 # Cheesy Cauliflower Au Gratin
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 cups raw cauliflower florets

--- a/docs/hearty/Vegetarian/Cloud-bread.md
+++ b/docs/hearty/Vegetarian/Cloud-bread.md
@@ -4,8 +4,31 @@ description: "Cloud bread - Vegetarian lean & green main."
 tags:
   - main
   - vegetarian
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
+  condiments: 0
+  snack: 0
 ---
 # Cloud bread
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ![Cloud bread](./Cloud-bread.png)
 

--- a/docs/hearty/Vegetarian/Coco-Lime-Noodles-with-Chili-Tamari-Tofu-Vegan.md
+++ b/docs/hearty/Vegetarian/Coco-Lime-Noodles-with-Chili-Tamari-Tofu-Vegan.md
@@ -5,13 +5,31 @@ tags:
   - main
   - vegetarian
   - tofu
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Coco-Lime Noodles with Chili Tamari Tofu (Vegan)
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 2 Servings
 

--- a/docs/hearty/Vegetarian/Curried-Cauliflower-Rice.md
+++ b/docs/hearty/Vegetarian/Curried-Cauliflower-Rice.md
@@ -6,10 +6,31 @@ tags:
   - vegetarian
   - cauliflower
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Curried Cauliflower Rice
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 servings

--- a/docs/hearty/Vegetarian/Eggplant-Shakshuka.md
+++ b/docs/hearty/Vegetarian/Eggplant-Shakshuka.md
@@ -6,12 +6,31 @@ tags:
   - vegetarian
   - eggplant
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Eggplant Shakshuka
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Each serving provides

--- a/docs/hearty/Vegetarian/Four-Cheese-Garlic-Spaghetti-Squash.md
+++ b/docs/hearty/Vegetarian/Four-Cheese-Garlic-Spaghetti-Squash.md
@@ -6,13 +6,31 @@ tags:
   - vegetarian
   - spaghetti-squash
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 2
+  condiments: 2
+  snack: 0
 ---
 # Four Cheese Garlic Spaghetti Squash
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings. Per Serving: ¼ Leaner | 2 Greens | 1 Healthy Fat | 2 Condiments
 

--- a/docs/hearty/Vegetarian/How-about-just-some-good-grilled-veggies-Youll-need-to-add-protein….md
+++ b/docs/hearty/Vegetarian/How-about-just-some-good-grilled-veggies-Youll-need-to-add-protein….md
@@ -8,11 +8,31 @@ tags:
   - zucchini
   - mediterranean
 servings: 3
-fueling:
-  condiments: 3
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Grilled Zucchini with Lemon and Feta
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Note: you'll need to add a protein for a complete meal.
 

--- a/docs/hearty/Vegetarian/Huevos-Rancheros.md
+++ b/docs/hearty/Vegetarian/Huevos-Rancheros.md
@@ -6,11 +6,31 @@ tags:
   - vegetarian
   - mexican
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Huevos Rancheros
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 2 cups Egg Beaters

--- a/docs/hearty/Vegetarian/Loaded-Cauliflower-bake.md
+++ b/docs/hearty/Vegetarian/Loaded-Cauliflower-bake.md
@@ -7,12 +7,31 @@ tags:
   - oven
   - cauliflower
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 0.5
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 0.5
+  snack: 0
 ---
 # Loaded Cauliflower bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ~~
 ~~

--- a/docs/hearty/Vegetarian/Margherita-Cauliflower-Crust-Pizza.md
+++ b/docs/hearty/Vegetarian/Margherita-Cauliflower-Crust-Pizza.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - pizza
 servings: 3
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 0.5
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 0.5
+  snack: 0
 ---
 # Margherita Cauliflower Crust Pizza
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 cups (19.02 oz) cooked Frozen Riced Cauliflower (6 greens)

--- a/docs/hearty/Vegetarian/Mock-Coconut-Pie.md
+++ b/docs/hearty/Vegetarian/Mock-Coconut-Pie.md
@@ -6,13 +6,31 @@ tags:
   - vegetarian
   - spaghetti-squash
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 0.17
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.5
-  condiments: 2
   greens: 1
+  condiments: 2
+  snack: 0
 ---
 # Mock Coconut Pie
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.17 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.17</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.17 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.17 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 servings

--- a/docs/hearty/Vegetarian/Mock-Tabbouleh-Recipe.md
+++ b/docs/hearty/Vegetarian/Mock-Tabbouleh-Recipe.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - mediterranean
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 3
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Mock Tabbouleh Recipe
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Vegetarian/Moms-Eggplant-Lasagna.md
+++ b/docs/hearty/Vegetarian/Moms-Eggplant-Lasagna.md
@@ -6,12 +6,31 @@ tags:
   - vegetarian
   - eggplant
 servings: 8
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 0.25
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 0.25
+  snack: 0
 ---
 # Mom's Eggplant Lasagna
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Vegetarian/Pepper-Stuffed-Shells.md
+++ b/docs/hearty/Vegetarian/Pepper-Stuffed-Shells.md
@@ -6,11 +6,31 @@ tags:
   - vegetarian
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 0
+  snack: 0
 ---
 # Pepper Stuffed "Shells"
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Vegetarian/Ricotta-Chocolate-Almond-Mousse.md
+++ b/docs/hearty/Vegetarian/Ricotta-Chocolate-Almond-Mousse.md
@@ -6,11 +6,31 @@ tags:
   - vegetarian
   - italian
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 0.5
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 1.75
+  snack: 1
 ---
 # Ricotta Chocolate Almond Mousse
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 Serving: 1/2 Lean, 1 3/4 Condiments, 1 Snack
 

--- a/docs/hearty/Vegetarian/Roasted-Veggie-Power-Bowl-with-Peanut-Sauce.md
+++ b/docs/hearty/Vegetarian/Roasted-Veggie-Power-Bowl-with-Peanut-Sauce.md
@@ -9,12 +9,31 @@ tags:
   - tofu
   - asian
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Roasted Veggie Power Bowl with Peanut Sauce
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 servings

--- a/docs/hearty/Vegetarian/SHAWARMA-SPICED-GRILLED-VEGETABLES.md
+++ b/docs/hearty/Vegetarian/SHAWARMA-SPICED-GRILLED-VEGETABLES.md
@@ -9,11 +9,31 @@ tags:
   - eggplant
   - asian
 servings: 6
-fueling:
-  condiments: 3
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # SHAWARMA SPICED GRILLED VEGETABLES
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving

--- a/docs/hearty/Vegetarian/Spaghetti-Squash-Alfredo.md
+++ b/docs/hearty/Vegetarian/Spaghetti-Squash-Alfredo.md
@@ -6,12 +6,31 @@ tags:
   - vegetarian
   - spaghetti-squash
   - italian
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Spaghetti Squash Alfredo
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 7 oz turkey, ground, 98% lean

--- a/docs/hearty/Vegetarian/Spaghetti-Squash-Caprese-Bake.md
+++ b/docs/hearty/Vegetarian/Spaghetti-Squash-Caprese-Bake.md
@@ -8,12 +8,31 @@ tags:
   - spaghetti-squash
   - italian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Spaghetti Squash Caprese Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Vegetarian/Spaghetti-Squash-Pizza-Crust.md
+++ b/docs/hearty/Vegetarian/Spaghetti-Squash-Pizza-Crust.md
@@ -7,11 +7,31 @@ tags:
   - spaghetti-squash
   - pizza
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 0
+  snack: 0
 ---
 # Spaghetti Squash Pizza Crust
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 4 servings

--- a/docs/hearty/Vegetarian/Spicy-Cauliflower-Cheese-Bake.md
+++ b/docs/hearty/Vegetarian/Spicy-Cauliflower-Cheese-Bake.md
@@ -7,12 +7,31 @@ tags:
   - oven
   - cauliflower
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 1
+  snack: 0
 ---
 # Spicy Cauliflower Cheese Bake
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/hearty/Vegetarian/Twice-Baked-Cauliflower.md
+++ b/docs/hearty/Vegetarian/Twice-Baked-Cauliflower.md
@@ -7,12 +7,31 @@ tags:
   - oven
   - shrimp
   - cauliflower
-fueling:
+LeanAndGreen:
   lean: 0.75
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Twice Baked Cauliflower
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.75 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.75</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.75 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.75 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 cups cauliflower florets

--- a/docs/hearty/Vegetarian/Vegan-Cauliflower-Alfredo-Spaghetti-Squash-with-Basil-Mushrooms.md
+++ b/docs/hearty/Vegetarian/Vegan-Cauliflower-Alfredo-Spaghetti-Squash-with-Basil-Mushrooms.md
@@ -7,12 +7,31 @@ tags:
   - cauliflower
   - spaghetti-squash
   - italian
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Vegan Cauliflower Alfredo Spaghetti Squash with Basil & Mushrooms
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 cup (5.26 oz) fresh red bell pepper (diced) - (2 greens)

--- a/docs/hearty/Vegetarian/Vegan-Tikka-Kababs.md
+++ b/docs/hearty/Vegetarian/Vegan-Tikka-Kababs.md
@@ -5,12 +5,31 @@ tags:
   - main
   - vegetarian
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.5
+  greens: 0
   condiments: 1.5
+  snack: 0
 ---
 # Vegan Tikka Kababs
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yields:
  2 servings - 10 kababs per serving

--- a/docs/hearty/Vegetarian/Zucchini-Boats-Stuffed-with-Ricotta-and-Pine-Nuts.md
+++ b/docs/hearty/Vegetarian/Zucchini-Boats-Stuffed-with-Ricotta-and-Pine-Nuts.md
@@ -8,10 +8,31 @@ tags:
   - italian
   - stuffed
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Zucchini Boats Stuffed with Ricotta and Pine Nuts
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 4 servings
 Per serving

--- a/docs/hearty/Vegetarian/Zucchini-Pizza-Casserole.md
+++ b/docs/hearty/Vegetarian/Zucchini-Pizza-Casserole.md
@@ -8,12 +8,31 @@ tags:
   - casserole
   - pizza
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 1
 ---
 # Zucchini Pizza Casserole
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 4 cups shredded zucchini (8 Greens)

--- a/docs/hearty/Vegetarian/Zucchini-Ravioli.md
+++ b/docs/hearty/Vegetarian/Zucchini-Ravioli.md
@@ -6,11 +6,31 @@ tags:
   - vegetarian
   - zucchini
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Zucchini Ravioli
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 2 servings

--- a/docs/hearty/Vegetarian/Zucchini-Spinach-Nests.md
+++ b/docs/hearty/Vegetarian/Zucchini-Spinach-Nests.md
@@ -6,10 +6,31 @@ tags:
   - vegetarian
   - zucchini
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2.67
+  snack: 0
 ---
 # Zucchini Spinach Nests
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.67</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 # Zucchini Spinach Nests
 

--- a/docs/hearty/Vegetarian/Zucchini-Tots.md
+++ b/docs/hearty/Vegetarian/Zucchini-Tots.md
@@ -6,10 +6,31 @@ tags:
   - vegetarian
   - zucchini
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 2.5
+  snack: 0
 ---
 # Zucchini Tots!!
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 2 cups grated zucchini

--- a/docs/hearty/index.md
+++ b/docs/hearty/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Mains"
-description: "All Lean & Green mains recipes (237 total)."
+description: "All Lean & Green mains recipes (238 total)."
 tags:
   - overview
   - main
@@ -10,6 +10,10 @@ hide:
 # Mains
 
 Every Lean & Green main, grouped by protein.
+
+## Mains (1)
+
+- [Mains](index/)
 
 ## Beef (38)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Lean & Green Recipes"
-description: "Browse 283 Lean & Green recipes by protein, method, cuisine, or dish type."
+description: "Browse 288 Lean & Green recipes by protein, method, cuisine, or dish type."
 tags:
   - overview
 hide:
@@ -10,7 +10,7 @@ hide:
 
 Welcome! Every recipe here fits the Lean & Green plan and is tagged for easy browsing. Use the search at the top, click any tag chip on a recipe to find similar dishes, or dive into the curated browse pages below.
 
-**283 recipes and tips** indexed.
+**288 recipes and tips** indexed.
 
 ## Browse pages
 
@@ -21,8 +21,8 @@ Welcome! Every recipe here fits the Lean & Green plan and is tagged for easy bro
 
 ## Course
 
-- [Appetizers](appetizers/) (10)
-- [Soups](soups/) (21)
-- [Salads](salads/) (11)
-- [Mains](hearty/) (237)
-- [Tips & Hacks](Tips-and-Hacks/) (4)
+- [Appetizers](appetizers/) (11)
+- [Soups](soups/) (22)
+- [Salads](salads/) (12)
+- [Mains](hearty/) (238)
+- [Tips & Hacks](Tips-and-Hacks/) (5)

--- a/docs/salads/Big-Mac-Salad.md
+++ b/docs/salads/Big-Mac-Salad.md
@@ -3,13 +3,31 @@ title: "Big Mac Salad"
 description: "Big Mac Salad - Lean & Green salad."
 tags:
   - salad
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0.5
 ---
 # Big Mac Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 1 serving
 

--- a/docs/salads/Broccoli-Sun-dried-Tomato-Chicken-Caesar-Salad.md
+++ b/docs/salads/Broccoli-Sun-dried-Tomato-Chicken-Caesar-Salad.md
@@ -4,12 +4,32 @@ description: "Broccoli, Sun-dried Tomato & Chicken Caesar Salad - Lean & Green s
 tags:
   - salad
 servings: 1
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
   greens: 3
+  condiments: 0
+  snack: 0
 ---
 # Broccoli, Sun-dried Tomato & Chicken Caesar Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 ⁠
 ## Ingredients
 - [ ] 1 ¼ cup of broccoli florets⁣⁠

--- a/docs/salads/Broccoli-Taco-Bowl.md
+++ b/docs/salads/Broccoli-Taco-Bowl.md
@@ -5,11 +5,31 @@ tags:
   - salad
   - mexican
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Broccoli Taco Bowl
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/salads/Caprese-Salad.md
+++ b/docs/salads/Caprese-Salad.md
@@ -5,12 +5,31 @@ tags:
   - salad
   - italian
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Caprese Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 1 serving⠀
 Per serving:⠀

--- a/docs/salads/Cauliflower-Potato-Salad.md
+++ b/docs/salads/Cauliflower-Potato-Salad.md
@@ -5,13 +5,31 @@ tags:
   - salad
   - cauliflower
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 0.33
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Cauliflower Potato Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.33 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.33 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.33 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 2 1/2 cup cauliflower, cooked and chopped (5 Greens)

--- a/docs/salads/Fresh-Poke-and-Avocado-Salad.md
+++ b/docs/salads/Fresh-Poke-and-Avocado-Salad.md
@@ -5,11 +5,31 @@ tags:
   - salad
   - tuna
 servings: 2
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Fresh Poke and Avocado Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 2 servings
 

--- a/docs/salads/Pasta-less-Italian-Salad.md
+++ b/docs/salads/Pasta-less-Italian-Salad.md
@@ -6,13 +6,31 @@ tags:
   - zucchini
   - italian
 servings: 7
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
   leanest: 1
   healthy_fats: 2
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Pasta-less Italian Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 2 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 7 servings, per serving you enjoy:
 3 Greens | 3 Condiments | 2 Healthy Fats

--- a/docs/salads/Salted-Caramel-Jicama-Salad.md
+++ b/docs/salads/Salted-Caramel-Jicama-Salad.md
@@ -4,12 +4,31 @@ description: "Salted Caramel Jicama Salad - Lean & Green salad."
 tags:
   - salad
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 0.25
-  condiments: 1.5
+  leanest: 0
+  healthy_fats: 0
   greens: 1.5
+  condiments: 1.5
+  snack: 1
 ---
 # Salted Caramel Jicama Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.25 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 0.25 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 YIELD:
 4 Servings

--- a/docs/salads/Spiralized-Greek-Cucumber-Salad-with-Lemon-and-Feta.md
+++ b/docs/salads/Spiralized-Greek-Cucumber-Salad-with-Lemon-and-Feta.md
@@ -5,12 +5,31 @@ tags:
   - salad
   - mediterranean
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Spiralized Greek Cucumber Salad with Lemon and Feta
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 3 servings

--- a/docs/salads/Taco-Salad.md
+++ b/docs/salads/Taco-Salad.md
@@ -4,13 +4,31 @@ description: "Taco Salad - Mexican Lean & Green salad."
 tags:
   - salad
   - mexican
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 0.5
+  leanest: 0
   healthy_fats: 1
-  condiments: 2
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Taco Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.5 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0.5 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 3 servings roman lettuce (3 greens)

--- a/docs/salads/Wedge-Salad.md
+++ b/docs/salads/Wedge-Salad.md
@@ -4,12 +4,31 @@ description: "Wedge Salad - Lean & Green salad."
 tags:
   - salad
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Wedge Salad
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 serving
 Each serving provides

--- a/docs/salads/index.md
+++ b/docs/salads/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Salads"
-description: "All Lean & Green salads recipes (11 total)."
+description: "All Lean & Green salads recipes (12 total)."
 tags:
   - overview
   - salad
@@ -11,7 +11,7 @@ hide:
 
 Hearty entrée salads and lighter sides.
 
-_11 recipes._
+_12 recipes._
 
 - [Big Mac Salad](Big-Mac-Salad/)
 - [Broccoli Taco Bowl](Broccoli-Taco-Bowl/)
@@ -20,6 +20,7 @@ _11 recipes._
 - [Cauliflower Potato Salad](Cauliflower-Potato-Salad/)
 - [Fresh Poke and Avocado Salad](Fresh-Poke-and-Avocado-Salad/)
 - [Pasta-less Italian Salad](Pasta-less-Italian-Salad/)
+- [Salads](index/)
 - [Salted Caramel Jicama Salad](Salted-Caramel-Jicama-Salad/)
 - [Spiralized Greek Cucumber Salad with Lemon and Feta](Spiralized-Greek-Cucumber-Salad-with-Lemon-and-Feta/)
 - [Taco Salad](Taco-Salad/)

--- a/docs/soups/Bacon-Cheeseburger-Soup-With-Cauliflower.md
+++ b/docs/soups/Bacon-Cheeseburger-Soup-With-Cauliflower.md
@@ -5,12 +5,31 @@ tags:
   - soup
   - cauliflower
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 2
+  condiments: 2
+  snack: 0
 ---
 # Bacon Cheeseburger Soup With Cauliflower
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 Serving
 

--- a/docs/soups/ChileRellenoChickenSoup.md
+++ b/docs/soups/ChileRellenoChickenSoup.md
@@ -5,10 +5,31 @@ tags:
   - soup
   - mexican
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Chile Relleno Chicken Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Servings
 

--- a/docs/soups/Cream-of-Baked-Potato-Soup.md
+++ b/docs/soups/Cream-of-Baked-Potato-Soup.md
@@ -6,12 +6,31 @@ tags:
   - oven
   - cauliflower
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 0.12
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Cream of Baked “Potato” Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.12 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.12</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.12 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.12 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 1 1/2 cups cauliflower, fresh

--- a/docs/soups/Crockpot-Gumbo.md
+++ b/docs/soups/Crockpot-Gumbo.md
@@ -8,12 +8,31 @@ tags:
   - cauliflower
   - cajun
 servings: 8
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Crockpot Gumbo
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients 
 - [ ] 3 lbs chicken thighs (boneless, skinless)

--- a/docs/soups/Crockpot-Taco-Soup.md
+++ b/docs/soups/Crockpot-Taco-Soup.md
@@ -6,13 +6,31 @@ tags:
   - slow-cooker
   - mexican
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 2
+  condiments: 3
+  snack: 0
 ---
 # Crockpot Taco Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 24 oz raw 95-97 % ground turkey~Yields 18 oz cooked (3 leaners)

--- a/docs/soups/CrockpotChickenTacoSoup.md
+++ b/docs/soups/CrockpotChickenTacoSoup.md
@@ -6,12 +6,31 @@ tags:
   - slow-cooker
   - mexican
 servings: 2
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2.25
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2.25
+  snack: 0
 ---
 # Crockpot Chicken Taco Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2.25</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Yield
 2 servings

--- a/docs/soups/Egg-Drop-Soup.md
+++ b/docs/soups/Egg-Drop-Soup.md
@@ -4,12 +4,31 @@ description: "Egg Drop Soup - Lean & Green soup."
 tags:
   - soup
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 0.33
+  leaner: 0
+  leanest: 0
   healthy_fats: 0.12
+  greens: 0
   condiments: 1.3
+  snack: 0
 ---
 # Egg Drop Soup 
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.33 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.33</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.33 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.33 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0.12</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">1.3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 1 serving 
 

--- a/docs/soups/Green-Chile-Chicken-Soup.md
+++ b/docs/soups/Green-Chile-Chicken-Soup.md
@@ -4,13 +4,31 @@ description: "Green Chile Chicken Soup - Mexican Lean & Green soup."
 tags:
   - soup
   - mexican
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 0.5
+  condiments: 3
+  snack: 0
 ---
 # Green Chile Chicken Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0.5</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield: 2 servings
 Per serving:

--- a/docs/soups/Healthy-Chicken-Pho-with-Zucchini-Noodles.md
+++ b/docs/soups/Healthy-Chicken-Pho-with-Zucchini-Noodles.md
@@ -4,13 +4,31 @@ description: "Healthy Chicken Pho with Zucchini Noodles - Lean & Green soup."
 tags:
   - soup
   - zucchini
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 1
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Healthy Chicken Pho with Zucchini Noodles
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 1 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Serves: 4 large bowls
 Each serving provides

--- a/docs/soups/Hearty-healthy-beef-stew-with-zucchini-noodles.md
+++ b/docs/soups/Hearty-healthy-beef-stew-with-zucchini-noodles.md
@@ -5,11 +5,31 @@ tags:
   - soup
   - zucchini
 servings: 6
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Hearty & Healthy Beef Stew with Zucchini Noodles
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 6 servings
 Per serving

--- a/docs/soups/Kabocha-Soup.md
+++ b/docs/soups/Kabocha-Soup.md
@@ -5,10 +5,31 @@ tags:
   - soup
   - crab
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Kabocha Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 6 servings

--- a/docs/soups/Mama-Mia-Meatball-Soup.md
+++ b/docs/soups/Mama-Mia-Meatball-Soup.md
@@ -6,12 +6,31 @@ tags:
   - zucchini
   - meatballs
 servings: 1
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 2
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 2
+  snack: 0
 ---
 # Mama Mia Meatball Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 1 Serving

--- a/docs/soups/Onion-Roasted-Chicken.md
+++ b/docs/soups/Onion-Roasted-Chicken.md
@@ -5,10 +5,31 @@ tags:
   - soup
   - oven
 servings: 8
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Onion Roasted Chicken
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Makes 8 servings
 1 protein

--- a/docs/soups/Roasted-Cauliflower-White-Cheddar-Soup.md
+++ b/docs/soups/Roasted-Cauliflower-White-Cheddar-Soup.md
@@ -6,11 +6,31 @@ tags:
   - oven
   - cauliflower
 servings: 6
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
   healthy_fats: 2
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Roasted Cauliflower White Cheddar Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">2</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 

--- a/docs/soups/Slow-Cooker-Mushroom-Soup.md
+++ b/docs/soups/Slow-Cooker-Mushroom-Soup.md
@@ -4,11 +4,31 @@ description: "Slow Cooker Mushroom Soup - Lean & Green soup made in the slow coo
 tags:
   - soup
   - slow-cooker
-fueling:
-  condiments: 3
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Slow Cooker Mushroom Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Serves 4
 Per serving: 3 green, 1 fat, ¼ leaner, and ~3 condiments

--- a/docs/soups/Thai-Chicken-Zoodle-Soup.md
+++ b/docs/soups/Thai-Chicken-Zoodle-Soup.md
@@ -6,13 +6,31 @@ tags:
   - zucchini
   - asian
 servings: 4
-fueling:
+LeanAndGreen:
+  lean: 0
   leaner: 4
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 1
+  condiments: 3
+  snack: 0
 ---
 # Thai Chicken Zoodle Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 4 (over 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 4 (over 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">4</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Lean + leaner + leanest = 4 (over 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Healthy fats target for this tier mix is 4 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 

--- a/docs/soups/This-weather-call-for-some-soup.md
+++ b/docs/soups/This-weather-call-for-some-soup.md
@@ -5,11 +5,31 @@ tags:
   - soup
   - slow-cooker
 servings: 5
-fueling:
+LeanAndGreen:
   lean: 1
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
+  greens: 0
   condiments: 3
+  snack: 0
 ---
 # Crock Pot Beef Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 Yield:
 5 servings

--- a/docs/soups/Tomatillo-Green-Chile-Pork-Stew.md
+++ b/docs/soups/Tomatillo-Green-Chile-Pork-Stew.md
@@ -4,12 +4,31 @@ description: "Tomatillo & Green Chile Pork Stew - Mexican Lean & Green soup."
 tags:
   - soup
   - mexican
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Tomatillo & Green Chile Pork Stew
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Ingredients
 - [ ] 2 cloves garlic

--- a/docs/soups/TurkeyChili.md
+++ b/docs/soups/TurkeyChili.md
@@ -5,13 +5,31 @@ tags:
   - soup
   - slow-cooker
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 0.17
+  leaner: 0
+  leanest: 0
   healthy_fats: 1
-  condiments: 3
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Turkey Chili
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--red" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.17 (under 1 portion)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0.17</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.17 (under 1 portion)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean + leaner + leanest = 0.17 (under 1 portion)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--red" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
 
 ## Makes 4 servings
 

--- a/docs/soups/Zucchini-Noodle-Lasagna-Soup.md
+++ b/docs/soups/Zucchini-Noodle-Lasagna-Soup.md
@@ -5,10 +5,32 @@ tags:
   - soup
   - zucchini
 servings: 3
-fueling:
+LeanAndGreen:
+  lean: 0
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 1
+  condiments: 0
+  snack: 0
 ---
 # Zucchini Noodle Lasagna Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--yellow" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="No protein declared."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--yellow" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 Makes 3 servings:
 
 ## Ingredients

--- a/docs/soups/Zuppa-Toscana-Soup.md
+++ b/docs/soups/Zuppa-Toscana-Soup.md
@@ -5,12 +5,32 @@ tags:
   - soup
   - cauliflower
 servings: 4
-fueling:
+LeanAndGreen:
   lean: 1
-  condiments: 3
+  leaner: 0
+  leanest: 0
+  healthy_fats: 0
   greens: 3
+  condiments: 3
+  snack: 0
 ---
 # Zuppa Toscana Soup
+
+<!-- LG:BEGIN -->
+<aside class="lg-badge lg-badge--green" aria-label="Lean and Green nutrition summary">
+  <header class="lg-badge__title">Lean &amp; Green</header>
+  <ul class="lg-badge__rows">
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Lean</span><span class="lg-badge__value">1</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leaner</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean + leaner + leanest = 1 portion (meets)."><span class="lg-badge__label">Leanest</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Healthy fats target for this tier mix is 0 (leanest 2 / leaner 1 / lean 0)."><span class="lg-badge__label">Healthy fats</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Lean & Green calls for 3 servings of non-starchy vegetables."><span class="lg-badge__label">Greens</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 3 condiment servings per day."><span class="lg-badge__label">Condiments</span><span class="lg-badge__value">3</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+    <li class="lg-badge__row lg-badge__row--green" title="Up to 1 optional snack per day."><span class="lg-badge__label">Snack</span><span class="lg-badge__value">0</span><span class="lg-badge__swatch" aria-hidden="true"></span></li>
+  </ul>
+</aside>
+<!-- LG:END -->
+
 (an adaptation of Olive Garden’s soup)
 
 ## Ingredients

--- a/docs/soups/index.md
+++ b/docs/soups/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Soups"
-description: "All Lean & Green soups recipes (21 total)."
+description: "All Lean & Green soups recipes (22 total)."
 tags:
   - overview
   - soup
@@ -11,7 +11,7 @@ hide:
 
 Brothy, creamy, and chunky soups - cozy without breaking the plan.
 
-_21 recipes._
+_22 recipes._
 
 - [Bacon Cheeseburger Soup With Cauliflower](Bacon-Cheeseburger-Soup-With-Cauliflower/)
 - [Chile Relleno Chicken Soup](ChileRellenoChickenSoup/)
@@ -29,6 +29,7 @@ _21 recipes._
 - [Onion Roasted Chicken](Onion-Roasted-Chicken/)
 - [Roasted Cauliflower White Cheddar Soup](Roasted-Cauliflower-White-Cheddar-Soup/)
 - [Slow Cooker Mushroom Soup](Slow-Cooker-Mushroom-Soup/)
+- [Soups](index/)
 - [Thai Chicken Zoodle Soup](Thai-Chicken-Zoodle-Soup/)
 - [Tomatillo & Green Chile Pork Stew](Tomatillo-Green-Chile-Pork-Stew/)
 - [Turkey Chili](TurkeyChili/)

--- a/docs/stylesheets/lean-green-badge.css
+++ b/docs/stylesheets/lean-green-badge.css
@@ -1,0 +1,115 @@
+/* Lean & Green nutrition-label badge.
+   Generated and injected by scripts/add_frontmatter.py between
+   <!-- LG:BEGIN --> and <!-- LG:END --> markers on every non-tip
+   recipe page. */
+
+.lg-badge {
+  --lg-green: #2e7d32;
+  --lg-yellow: #f9a825;
+  --lg-red: #c62828;
+  --lg-bg: #ffffff;
+  --lg-fg: #111111;
+  --lg-border: #111111;
+  --lg-divider: rgba(0, 0, 0, 0.12);
+
+  display: block;
+  max-width: 22rem;
+  margin: 1rem 0 1.5rem;
+  padding: 0.75rem 1rem 0.85rem;
+  background: var(--lg-bg);
+  color: var(--lg-fg);
+  border: 2px solid var(--lg-border);
+  border-radius: 4px;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 0.9rem;
+  line-height: 1.3;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
+}
+
+.lg-badge__title {
+  font-weight: 800;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  border-bottom: 4px solid var(--lg-border);
+  padding-bottom: 0.35rem;
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+}
+
+.lg-badge__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.lg-badge__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid var(--lg-divider);
+}
+
+.lg-badge__row:last-child {
+  border-bottom: none;
+}
+
+.lg-badge__label {
+  flex: 1 1 auto;
+  font-weight: 600;
+}
+
+.lg-badge__value {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  min-width: 1.5rem;
+  text-align: right;
+}
+
+.lg-badge__swatch {
+  display: inline-block;
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 50%;
+  background: var(--lg-green);
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.lg-badge__row--green .lg-badge__swatch { background: var(--lg-green); }
+.lg-badge__row--yellow .lg-badge__swatch { background: var(--lg-yellow); }
+.lg-badge__row--red .lg-badge__swatch { background: var(--lg-red); }
+
+.lg-badge--green { border-color: var(--lg-green); }
+.lg-badge--yellow { border-color: var(--lg-yellow); }
+.lg-badge--red { border-color: var(--lg-red); }
+
+.lg-badge--green .lg-badge__title { border-bottom-color: var(--lg-green); }
+.lg-badge--yellow .lg-badge__title { border-bottom-color: var(--lg-yellow); }
+.lg-badge--red .lg-badge__title { border-bottom-color: var(--lg-red); }
+
+@media (max-width: 600px) {
+  .lg-badge {
+    max-width: 100%;
+  }
+  .lg-badge__rows {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.8rem;
+  }
+  .lg-badge__row {
+    border-bottom: none;
+    padding: 0.15rem 0;
+    flex: 0 0 auto;
+  }
+  .lg-badge__value { min-width: 1rem; }
+}
+
+@media (prefers-color-scheme: dark) {
+  .lg-badge {
+    --lg-bg: #1e1e1e;
+    --lg-fg: #f5f5f5;
+    --lg-border: #f5f5f5;
+    --lg-divider: rgba(255, 255, 255, 0.18);
+  }
+  .lg-badge__swatch { border-color: rgba(255, 255, 255, 0.3); }
+}

--- a/scripts/add_frontmatter.py
+++ b/scripts/add_frontmatter.py
@@ -2,10 +2,13 @@
 """Generate Zensical front matter for every recipe under docs/.
 
 Re-runnable: existing `---` front matter is stripped and regenerated so
-the script is the single source of truth for tags/description/fueling.
+the script is the single source of truth for tags/description/LeanAndGreen
+data, and the rendered nutrition badge between `<!-- LG:BEGIN -->` and
+`<!-- LG:END -->` is also stripped and regenerated.
 """
 import json
 import re
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -74,7 +77,13 @@ LEAN_RE = re.compile(rf"({NUM})\s+(leanest|leaner|lean)s?\b", re.I)
 HEALTHY_FAT_RE = re.compile(rf"({NUM})\s+healthy\s*fats?", re.I)
 CONDIMENT_RE = re.compile(rf"({NUM})\s+condiments?", re.I)
 GREEN_RE = re.compile(rf"({NUM})\s+greens?\b", re.I)
+SNACK_RE = re.compile(rf"({NUM})\s+(?:optional\s+)?snacks?\b", re.I)
 FRONT_MATTER_RE = re.compile(r"\A---\s*\n.*?\n---\s*\n?", re.S)
+LG_BLOCK_RE = re.compile(
+    r"\n*<!-- LG:BEGIN -->.*?<!-- LG:END -->\n*", re.S
+)
+
+LG_KEYS = ("lean", "leaner", "leanest", "healthy_fats", "greens", "condiments", "snack")
 
 
 def parse_number(s: str):
@@ -192,29 +201,42 @@ def derive_meta(path: Path, content: str) -> dict:
                 pass
             break
 
-    fueling: dict = {}
+    lg: dict = {k: 0 for k in LG_KEYS}
     lm = extract_fueling(LEAN_RE, summary, content)
     if lm:
         v = fmt_num(parse_number(lm.group(1)))
         if v is not None:
-            fueling[lm.group(2).lower()] = v
+            lg[lm.group(2).lower()] = v
     hm = extract_fueling(HEALTHY_FAT_RE, summary, content)
     if hm:
         v = fmt_num(parse_number(hm.group(1)))
         if v is not None:
-            fueling["healthy_fats"] = v
+            lg["healthy_fats"] = v
     cm = extract_fueling(CONDIMENT_RE, summary, content)
     if cm:
         v = fmt_num(parse_number(cm.group(1)))
         if v is not None:
-            fueling["condiments"] = v
+            lg["condiments"] = v
     gm = extract_fueling(GREEN_RE, summary, content)
     if gm:
         v = fmt_num(parse_number(gm.group(1)))
         if v is not None:
-            fueling["greens"] = v
-    if fueling:
-        out["fueling"] = fueling
+            lg["greens"] = v
+    sm = extract_fueling(SNACK_RE, summary, content)
+    if sm:
+        v = fmt_num(parse_number(sm.group(1)))
+        if v is not None:
+            lg["snack"] = v
+
+    tier_sum = sum(float(lg[k]) for k in ("lean", "leaner", "leanest"))
+    if not (abs(tier_sum) < 1e-6 or abs(tier_sum - 1) < 1e-6):
+        rel = path.relative_to(ROOT).as_posix()
+        print(
+            f"WARN {rel}: lean+leaner+leanest = {tier_sum} (expected 0 or 1)",
+            file=sys.stderr,
+        )
+
+    out["LeanAndGreen"] = lg
     return out
 
 
@@ -255,6 +277,133 @@ def yaml_str(s: str) -> str:
     return json.dumps(s, ensure_ascii=False)
 
 
+COLOR_RANK = {"green": 0, "yellow": 1, "red": 2}
+
+
+def _fmt_value(v) -> str:
+    if isinstance(v, float) and abs(v - round(v)) < 1e-6:
+        return str(int(round(v)))
+    return str(v)
+
+
+def evaluate_lean_and_green(lg: dict) -> list[dict]:
+    """Return per-row dicts with label, value, color, and tooltip."""
+    lean = float(lg.get("lean", 0))
+    leaner = float(lg.get("leaner", 0))
+    leanest = float(lg.get("leanest", 0))
+    healthy_fats = float(lg.get("healthy_fats", 0))
+    greens = float(lg.get("greens", 0))
+    condiments = float(lg.get("condiments", 0))
+    snack = float(lg.get("snack", 0))
+
+    tier_sum = lean + leaner + leanest
+    if abs(tier_sum - 1) < 1e-6:
+        tier_color = "green"
+        tier_tip = "Lean + leaner + leanest = 1 portion (meets)."
+    elif tier_sum > 1 + 1e-6:
+        tier_color = "red"
+        tier_tip = f"Lean + leaner + leanest = {_fmt_value(tier_sum)} (over 1 portion)."
+    elif tier_sum > 1e-6:
+        tier_color = "yellow"
+        tier_tip = f"Lean + leaner + leanest = {_fmt_value(tier_sum)} (under 1 portion)."
+    else:
+        tier_color = "green"
+        tier_tip = "No protein declared."
+
+    fats_target = 2 * leanest + 1 * leaner + 0 * lean
+    if abs(healthy_fats - fats_target) < 1e-6:
+        fats_color = "green"
+    elif healthy_fats < fats_target:
+        fats_color = "yellow"
+    else:
+        fats_color = "red"
+    fats_tip = (
+        f"Healthy fats target for this tier mix is {_fmt_value(fats_target)} "
+        f"(leanest 2 / leaner 1 / lean 0)."
+    )
+
+    if abs(greens - 3) < 1e-6:
+        greens_color = "green"
+    elif greens < 3:
+        greens_color = "yellow"
+    else:
+        greens_color = "red"
+    greens_tip = "Lean & Green calls for 3 servings of non-starchy vegetables."
+
+    if condiments <= 3 + 1e-6:
+        condiments_color = "green"
+    else:
+        condiments_color = "red"
+    condiments_tip = "Up to 3 condiment servings per day."
+
+    if snack <= 1 + 1e-6:
+        snack_color = "green"
+    else:
+        snack_color = "red"
+    snack_tip = "Up to 1 optional snack per day."
+
+    return [
+        {"key": "lean", "label": "Lean", "value": _fmt_value(lean),
+         "color": tier_color, "title": tier_tip},
+        {"key": "leaner", "label": "Leaner", "value": _fmt_value(leaner),
+         "color": tier_color, "title": tier_tip},
+        {"key": "leanest", "label": "Leanest", "value": _fmt_value(leanest),
+         "color": tier_color, "title": tier_tip},
+        {"key": "healthy_fats", "label": "Healthy fats",
+         "value": _fmt_value(healthy_fats), "color": fats_color,
+         "title": fats_tip},
+        {"key": "greens", "label": "Greens", "value": _fmt_value(greens),
+         "color": greens_color, "title": greens_tip},
+        {"key": "condiments", "label": "Condiments",
+         "value": _fmt_value(condiments), "color": condiments_color,
+         "title": condiments_tip},
+        {"key": "snack", "label": "Snack", "value": _fmt_value(snack),
+         "color": snack_color, "title": snack_tip},
+    ]
+
+
+def render_lean_and_green_badge(meta: dict) -> str:
+    """Render the per-recipe Lean & Green nutrition badge as HTML."""
+    lg = meta.get("LeanAndGreen") or {k: 0 for k in LG_KEYS}
+    rows = evaluate_lean_and_green(lg)
+    overall = max((r["color"] for r in rows), key=lambda c: COLOR_RANK[c])
+
+    lines = [
+        "<!-- LG:BEGIN -->",
+        f'<aside class="lg-badge lg-badge--{overall}" '
+        'aria-label="Lean and Green nutrition summary">',
+        '  <header class="lg-badge__title">Lean &amp; Green</header>',
+        '  <ul class="lg-badge__rows">',
+    ]
+    for r in rows:
+        lines.append(
+            f'    <li class="lg-badge__row lg-badge__row--{r["color"]}" '
+            f'title="{r["title"]}">'
+            f'<span class="lg-badge__label">{r["label"]}</span>'
+            f'<span class="lg-badge__value">{r["value"]}</span>'
+            '<span class="lg-badge__swatch" aria-hidden="true"></span>'
+            '</li>'
+        )
+    lines.append("  </ul>")
+    lines.append("</aside>")
+    lines.append("<!-- LG:END -->")
+    return "\n".join(lines)
+
+
+def inject_badge(body: str, badge: str) -> str:
+    """Insert the badge block immediately after the first H1 in the body."""
+    body = LG_BLOCK_RE.sub("\n\n", body, count=1)
+    m = re.search(r"^#\s+.+?$", body, re.M)
+    if not m:
+        return body
+    end = m.end()
+    after = body[end:]
+    after = re.sub(r"^\s*\n+", "\n\n", after, count=1)
+    if not after.startswith("\n\n"):
+        after = "\n\n" + after.lstrip("\n")
+    return body[:end] + "\n\n" + badge + after
+
+
 def to_front_matter(title, description, tags, meta) -> str:
     lines = [
         "---",
@@ -266,10 +415,10 @@ def to_front_matter(title, description, tags, meta) -> str:
         lines.extend(f"  - {t}" for t in tags)
     if "servings" in meta:
         lines.append(f"servings: {meta['servings']}")
-    if "fueling" in meta:
-        lines.append("fueling:")
-        for k, v in meta["fueling"].items():
-            lines.append(f"  {k}: {v}")
+    if "LeanAndGreen" in meta:
+        lines.append("LeanAndGreen:")
+        for k in LG_KEYS:
+            lines.append(f"  {k}: {meta['LeanAndGreen'][k]}")
     lines.append("---")
     lines.append("")
     return "\n".join(lines)
@@ -285,11 +434,15 @@ def should_skip(path: Path) -> bool:
 def process(path: Path) -> None:
     content = path.read_text()
     content = FRONT_MATTER_RE.sub("", content, count=1)
+    content = LG_BLOCK_RE.sub("\n\n", content, count=1)
     fallback = path.stem.replace("-", " ").replace("_", " ")
     title = extract_title(content, fallback)
     tags = derive_tags(path, content, title)
     meta = derive_meta(path, content)
     description = build_description(title, tags)
+    if not is_tip(path) and "LeanAndGreen" in meta:
+        badge = render_lean_and_green_badge(meta)
+        content = inject_badge(content, badge)
     path.write_text(to_front_matter(title, description, tags, meta) + content)
 
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -5,6 +5,7 @@ repo_url = "https://github.com/KevinRaney/Recipes"
 repo_name = "KevinRaney/Recipes"
 edit_uri = "edit/main/docs/"
 copyright = "Copyright © 2026 Recipes.Raney.co"
+extra_css = ["stylesheets/lean-green-badge.css"]
 
 [project.theme]
 features = [


### PR DESCRIPTION
## Summary

Closes #14.

- Renames front-matter `fueling` → `LeanAndGreen` and always emits all seven sub-keys (`lean`, `leaner`, `leanest`, `healthy_fats`, `greens`, `condiments`, `snack`), defaulting to `0`. Adds a `snack` extractor and warns on stderr when `lean + leaner + leanest` ∉ {0, 1}.
- Generates a per-recipe Lean & Green nutrition badge between `<!-- LG:BEGIN -->` and `<!-- LG:END -->` markers, injected after the H1 on every non-tip recipe and color-coded per the Optavia criteria table in the issue (green=meets, yellow=under, red=over; overall = worst row). Strips and regenerates the block on each run.
- Adds `docs/stylesheets/lean-green-badge.css` (nutrition-label aesthetic, `prefers-color-scheme: dark` aware, mobile-collapsing rows) and registers it via `extra_css` in `zensical.toml`.

## Test plan

- [x] `python3 scripts/add_frontmatter.py` regenerates 288 files; `python3 scripts/build_browse.py` succeeds.
- [x] Re-running both scripts produces zero diff (idempotent).
- [x] `grep -rn '^fueling:' docs/` returns nothing.
- [x] Every non-tip recipe has a single `<!-- LG:BEGIN -->`/`<!-- LG:END -->` block.
- [x] `.venv/bin/zensical build -s` reports `No issues found`.
- [ ] Reviewer to spot-check rendered badge in `zensical serve` for color accuracy on a few mixed-tier recipes.

## Open questions from the issue

The script currently follows the spec literally (`LeanAndGreen` PascalCase, condiments > 3 → red, snack > 1 → red, etc.). The "open questions" from #14 (snake_case rename, daily-vs-per-meal condiment budget, vegetarian tier mapping, aggregate score, Optavia link in the badge) are not addressed here — happy to follow up in a separate PR once direction is decided.

https://claude.ai/code/session_01VLXuykqftaBHxwhWvuXWHg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLXuykqftaBHxwhWvuXWHg)_